### PR TITLE
TEST: Add a topic to the selection (see #35)

### DIFF
--- a/features/step_definitions/portfolio.rb
+++ b/features/step_definitions/portfolio.rb
@@ -6,6 +6,21 @@ Capybara.default_driver = :selenium_chrome_headless
 Capybara.app_host = "http://localhost:3000"
 Capybara.default_max_wait_time = 10
 
+def getUUID(itemName)
+  uuid = nil
+
+  case itemName
+  when "Ateliers du Carmel du Mans"
+    uuid = "0edea8e39068ed49a8f555a660d7cc68"
+  when "David Tremlett"
+    uuid = "7123a482ef397d4cb464ea3ec37655e0"
+  when "1868"
+    uuid = "29e7a2c6a601c040985ade144901cb1f"
+  end
+
+  return uuid
+end
+
 # Conditions
 
 Soit("le point de vue {string} rattaché au portfolio {string}") do |viewpoint, portfolio|
@@ -16,18 +31,48 @@ Soit("le corpus {string} rattaché au portfolio {string}") do |viewpoint, portfo
   # On the remote servers
 end
 
+Soit("le thème {string} rattaché au point de vue {string}") do |topic, viewpoint|
+  # On the remote servers
+end
+
+Soit("l'item {string} rattaché au thème {string}") do |item, topic|
+  # On the remote servers
+end
+
 Soit("{string} le portfolio spécifié dans la configuration") do |portfolio|
   case portfolio
-  when "vitraux" 
+  when "vitraux"
     true #current configuration
-  when "indéfini" 
+  when "indéfini"
     pending "alternate configuration"
   else
     false
   end
 end
 
-# Events 
+Soit("les thèmes {string} sont sélectionnés") do |topics|
+  first = true
+  uri = "/?"
+
+  topics.split("|").each do |topic|
+    uuid = getUUID(topic)
+
+    if (first)
+      uri += "t=" + uuid
+      first = false
+    else
+      uri += "&t=" + uuid
+    end
+  end
+
+  visit uri
+end
+
+Soit("la liste des thèmes sélectionnés est vide") do
+  visit "/"
+end
+
+# Events
 
 Quand("un visiteur ouvre la page d'accueil du site") do
   visit "/"
@@ -35,6 +80,10 @@ end
 
 Quand("un visiteur ouvre la page d‘accueil d‘un site dont l‘adresse commence par {string}") do |portfolio|
   visit "/"
+end
+
+Quand("un visiteur clique sur le thème {string}") do |topic|
+  click_link(topic)
 end
 
 # Outcomes
@@ -51,3 +100,32 @@ Alors("un des corpus affichés est {string}") do |corpus|
   expect(page).to have_content corpus
 end
 
+# J'ai formulé cette étape de cette manière simplement car il n'est pas possible d'avoir une étape
+# "Soit" et une étape "Alors" ayant toutes les deux la même formulation.
+
+# Malgré ça, l'étape teste bien le fait que les thèmes sont sélectionnés par l'URL, ce qui n'a
+# rien à voir avec l'affichage.
+
+Alors("les thèmes {string} sont surlignés") do |topics|
+  uri = URI.parse(current_url).to_s
+
+  topics.split("|").each do |topic|
+    uuid = getUUID(topic)
+
+    if (uuid == nil)
+      pending "undefined UUID"
+    elsif (!uri.include? getUUID(topic))
+      false
+    end
+  end
+
+  true
+end
+
+Alors ("l'item {string} est affiché") do |item|
+  expect(page).to have_content item
+end
+
+Alors ("l'item {string} n'est pas affiché") do |item|
+  expect(page).not_to have_content item
+end

--- a/features/theme_add.feature
+++ b/features/theme_add.feature
@@ -1,0 +1,35 @@
+#language: fr
+
+Fonctionnalité: Ajouter un thème à la sélection actuelle
+
+Contexte:
+ Soit le point de vue "Histoire de l'art" rattaché au portfolio "vitraux"
+ Soit le point de vue "Histoire des religions" rattaché au portfolio "vitraux"
+
+ Soit le corpus "Vitraux - Bénel" rattaché au portfolio "vitraux"
+ Soit le corpus "Vitraux - Recensement" rattaché au portfolio "vitraux"
+
+ Soit le thème "Ateliers du Carmel du Mans" rattaché au point de vue "Histoire de l'art"
+ Soit le thème "1868" rattaché au point de vue "Histoire de l'art"
+ Soit le thème "David Tremlett" rattaché au point de vue "Histoire de l'art"
+
+ Soit l'item "DSN 001" rattaché au thème "Ateliers du Carmel du Mans"
+ Soit l'item "DSN 001" rattaché au thème "1868"
+ Soit l'item "DSN 003" rattaché au thème "Atelier du Carmel du Mans"
+ Soit l'item "Villenauxe-la-Grande" rattaché au thème "David Tremlett"
+
+Scénario: Ajouter un thème à une sélection vide
+ Soit la liste des thèmes sélectionnés est vide
+ Quand un visiteur clique sur le thème "Ateliers du Carmel du Mans"
+ Alors les thèmes "Ateliers du Carmel du Mans" sont surlignés
+ Et l'item "DSN 001" est affiché
+ Et l'item "DSN 003" est affiché
+ Et l'item "Villenauxe-la-Grande" n'est pas affiché
+
+Scénario: Ajouter un thème à une sélection non vide
+ Soit les thèmes "Ateliers du Carmel du Mans" sont sélectionnés
+ Quand un visiteur clique sur le thème "1868"
+ Alors les thèmes "Ateliers du Carmel du Mans|1868" sont surlignés
+ Et l'item "DSN 001" est affiché
+ Et l'item "DSN 003" n'est pas affiché
+ Et l'item "Villenauxe-la-Grande" n'est pas affiché


### PR DESCRIPTION
## Content

These are suitable Cucumber scenarios and Capybara steps to test feature #35.

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [X] corresponds to a contribution that should be notified to users,
    - [X] does not generate new errors or warnings at compile or test time,
    - [X] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [X] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `TEST` when it concerns an acceptance test,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [X] be followed by a colon (`:`) with one space after and no space before,
    - [X] be followed by a title as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [X] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [X] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [X] related to this very contribution (feature, fix...),
    - [X] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [X] without any typo in variable, class or function names,
    - [X] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
