### PR TITLE
FEATURE: allow per-portfolio configuration (see #94)

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,0 +1,31 @@
+import conf from './config.json';
+
+let portfolio = conf.user;
+
+/*
+ * Get the "prop" config from config.json
+ * It is either:
+ * - customization[prop] for the current portfolio
+ * - default[prop] if there is no custom conf
+ * - the given "def" object if there is no default conf
+ */
+const getConfig = (prop, def) => {
+    if (conf.default && conf.default[prop]) {
+        Object.keys(conf.default[prop]).forEach(key => {
+            def[key] = conf.default[prop][key];
+        });
+    }
+
+    if (conf.customization && conf.customization[portfolio]) {
+        let custom = conf.customization[portfolio];
+        if (custom[prop]) {
+            Object.keys(custom[prop]).forEach(key => {
+                def[key] = custom[prop][key];
+            });
+        }
+    }
+    return def;
+}
+
+export default getConfig;
+


### PR DESCRIPTION
Co-authored-by: @winwave and @giabao5995 

## Content

We propose a new method allowing for custom configuration per portfolio.
The configuration file looks like:

```json
{
  "user": "open-access",
  "services": [
    "http://argos2.hypertopic.org",
    "http://steatite.hypertopic.org"
  ],
  "default": {
    "itemView": {
      "mode": "profile"
    }
  },
  "customization": {
    "open-access": {
      "itemView": {
        "mode": "article"
      }
    }
  }
}
```

We define two new keys: `default` and `customization`.

### `default`

Contains default configuration objects. If absents, the code is expected to contain hard-coded replacement values (see "Usage").

### `customization`

Contains custom configuration objects. Keys are the portfolios, so that the method will select different configuration sets on different portfolios. See the example.

### Usage

```js
import getConfig from '../../config/config.js';

let itemView = getConfig('itemView', {
  mode: 'picture'
});
```

When the portfolio is `open-access`, `mode` will be `article` (defined in `customization.open-access.itemView`). On other portfolios, it will be `profile` (defined in `default.itemView`). If not defined in `default`, it will fallback to `picture` (hardcoded argument in the JS code).

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [x] corresponds to a contribution that should be notified to users,
    - [x] does not generate new errors or warnings at compile or test time,
    - [x] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [x] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `TEST` when it concerns an acceptance test,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [x] be followed by a colon (`:`) with one space after and no space before,
    - [x] be followed by a title as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [x] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [x] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [x] related to this very contribution (feature, fix...),
    - [x] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [x] without any typo in variable, class or function names,
    - [x] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
