### PR TITLE
TEST: Set an item's attribute (see #31)

### DIFF
--- a/features/annuaire_setAttributs.feature
+++ b/features/annuaire_setAttributs.feature
@@ -1,0 +1,22 @@
+#language: fr
+
+Fonctionnalité: Set an item's attributs
+
+Contexte:
+
+  Soit l'item "ABT" spécifié dans la configuration
+
+Scénario: Créer un nouvel attribut
+
+  Soit le bouton "Créer" rattaché au point de vue "Attributs du document"
+  Quand un visiteur clique sur le bouton "Créer"
+  Alors un champ de nom de l'attribut appelé "key" est affiché
+  Et un champ de valeur de l'attribut appelé "value" est affiché
+
+Scénario: Enregistrer le nouvel attribut
+
+  Soit le bouton "Créer" cliqué
+  Quand un visiteur saisit "address" dans le champ de nom de l'attribut
+  Et il saisit "UTT" dans le champ de valeur de l'attribut
+  Et il clique sur le bouton "Valider"
+  Alors un nouvel attibut "address" applé "UTT" est enregistré

--- a/features/step_definitions/item.rb
+++ b/features/step_definitions/item.rb
@@ -13,13 +13,43 @@ Soit("{string} l'item affiché") do |item|
   click_on item
 end
 
+#conditions set an item's attributs
+Soit("le point de vue {string} rattaché à la page personelle") do |viewpoint|
+end
 
+Soit("le bouton {string} rattaché au point de vue {string}") do |button, viewpoint|
+end
+
+Soit("l'item {string} spécifié dans la configuration") do |item|
+  visit "http://localhost:3000/item/Vitraux%20-%20B%C3%A9nel/11d3601f5f400071f968da6e192ddb7e86f27286"
+end
+
+Soit("le bouton {string} cliqué") do |button|
+  click_button button
+end
 # Events
 
 Quand("on choisit la rubrique {string}") do |topic|
   click_on topic
 end
 
+#Events set item's attributs
+
+Quand("un visiteur clique sur le bouton {string}") do |button|
+  click_button button
+end
+
+Quand("un visiteur saisit {string} dans le champ de nom de l'attribut") do |attribut_name|
+  fill_in "key", with: attribut_name
+end
+
+Quand("il saisit {string} dans le champ de valeur de l'attribut") do |attribut_value|
+  fill_in "value", with: attribut_value
+end
+
+Quand("il clique sur le bouton {string}") do |button|
+  click_button button
+end
 # Outcomes
 
 Alors("le titre de l'item affiché est {string}") do |item|
@@ -35,3 +65,16 @@ Alors("une des rubriques de l'item est {string}") do |topic|
   expect(page).to have_content(topic)
 end
 
+#Outcomes set item
+Alors("un champ de nom de l'attribut appelé {string} est affiché") do |attKey|
+  expect(page).to have_field attKey
+end
+
+Alors("un champ de valeur de l'attribut appelé {string} est affiché") do |attValue|
+ expect(page).to have_field attValue
+end
+
+Alors("un nouvel attibut {string} applé {string} est enregistré") do |attKey,attValue|
+  expect(page).to have_css("div.Key", text: attKey, wait: 10)
+  expect(page).to have_css("div.Value", text: attValue, wait: 10)
+end


### PR DESCRIPTION
## Content

Add a scenario file setAttributs.feature in feature, add test in /set_definitions/item.rb.

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [x] corresponds to a contribution that should be notified to users,
    - [x] does not generate new errors or warnings at compile or test time,
    - [x] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [x] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `TEST` when it concerns an acceptance test,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [x] be followed by a colon (`:`) with one space after and no space before,
    - [x] be followed by a title as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [x] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [x] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [x] related to this very contribution (feature, fix...),
    - [x] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [x] without any typo in variable, class or function names,
    - [x] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
