### PR TITLE
Article view

### DIFF
--- a/src/components/Corpora/Corpora.jsx
+++ b/src/components/Corpora/Corpora.jsx
@@ -1,5 +1,13 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
+import getConfig from '../../config/config.js';
+
+// Get the configured list display mode
+let listView = getConfig('listView', {
+  mode: 'picture',
+  name: 'name',
+  image: 'thumbnail'
+});
 
 class Corpora extends Component {
 
@@ -19,21 +27,56 @@ class Corpora extends Component {
 
   _getItems() {
     return this.props.items.map(item =>
-        <Item key={item.id} name={item.name[0]} thumbnail={item.thumbnail[0]} 
+        <Item key={item.id} item={item}
           id={item.corpus+'/'+item.id} />
-    ); 
+    );
   }
 
 }
 
 function Item(props) {
-  let uri = '/item/' + props.id;
+  switch (listView.mode) {
+  case 'article':
+    return Article(props.item);
+  case 'picture':
+    return Picture(props.item);
+  default:
+    return Picture(props.item);
+  }
+}
+
+function getString(obj) {
+  if (Array.isArray(obj)) {
+    return obj.map(val => getString(val)).join(', ');
+  }
+  return String(obj);
+}
+
+function Article(item) {
+  let propList = listView.props.map(key => {
+    return <li><strong>{key}</strong>: {getString(item[key])}</li>;
+  });
+
+  let uri = `/item/${item.corpus}/${item.id}`;
+  let name = getString(item[listView.name]);
+  return (
+    <div className="Article">
+      <div className="ArticleTitle"><Link to={uri}>{name}</Link></div>
+      <ul>{propList}</ul>
+    </div>
+  );
+}
+
+function Picture(item) {
+  let uri = `/item/${item.corpus}/${item.id}`;
+  let img = getString(item[listView.image]);
+  let name = getString(item[listView.name]);
   return (
     <div className="Item">
       <Link to={uri}>
-        <img src={props.thumbnail} alt={props.name} />
+        <img src={img} alt={name}/>
       </Link>
-      <div>{props.name}</div>
+      <div>{name}</div>
     </div>
   );
 }

--- a/src/components/Item/Item.jsx
+++ b/src/components/Item/Item.jsx
@@ -4,7 +4,24 @@ import Hypertopic from 'hypertopic';
 import groupBy from 'json-groupby';
 import Autosuggest from 'react-autosuggest';
 import conf from '../../config/config.json';
+import getConfig from '../../config/config.js';
 import '../../styles/App.css';
+
+// Get the configured item display mode
+let itemView = getConfig('itemView', {
+  mode: 'picture',
+  name: 'name',
+  image: 'resource',
+  linkTo: 'resource',
+  hiddenProps: ['topic', 'resource', 'thumbnail', 'isCreatable']
+});
+
+function getString(obj) {
+  if (Array.isArray(obj)) {
+    return obj.map(val => getString(val)).join(', ');
+  }
+  return String(obj);
+}
 
 class Item extends Component {
   constructor() {
@@ -21,13 +38,14 @@ class Item extends Component {
   }
 
   render() {
+    let name = getString(this.state[itemView.name]);
     let attributes = this._getAttributes();
     let viewpoints = this._getViewpoints();
     let attributeButtonLabel = this.state.isCreatable? 'Valider' : 'Créer';
     let attributeForm = this.state.isCreatable? this._getAttributeCreationForm() : '';
     return (
       <div className="App">
-        <h1>{this.state.name}</h1>
+        <h1>{name}</h1>
         <div className="Status">Item</div>
         <div className="App-content">
           <div className="Description">
@@ -42,9 +60,7 @@ class Item extends Component {
             {viewpoints}
           </div>
           <div className="Subject">
-            <div>
-              <img src={this.state.resource} alt="resource" />
-            </div>
+            <ShowItem item={this.state} />
           </div>
         </div>
       </div>
@@ -53,7 +69,7 @@ class Item extends Component {
 
   _getAttributes() {
     return Object.entries(this.state)
-      .filter(x => !['topic', 'resource', 'thumbnail', 'isCreatable'].includes(x[0]))
+      .filter(x => !itemView.hiddenProps.includes(x[0]))
       .map(x => (
         <div className="Attribute" key={x[0]}>
           <div className="Key">{x[0]}</div>
@@ -176,6 +192,38 @@ class Item extends Component {
         .catch(error => console.log(`error : ${error}`));
     }
   }
+}
+
+function ShowItem(props) {
+  switch (itemView.mode) {
+  case 'article':
+    return Article(props.item);
+  case 'picture':
+    return Picture(props.item);
+  default:
+    return Picture(props.item);
+  }
+}
+
+function Article(item) {
+  let text = getString(item[itemView.text]);
+  let link = getString(item[itemView.linkTo]);
+  return (
+    <div>
+      <p>{text}</p>
+      <a href={link} target="_blank">Télécharger</a>
+    </div>
+  );
+}
+
+function Picture(item) {
+  let img = getString(item[itemView.image]);
+  let name = getString(item[itemView.name]);
+  return (
+    <div>
+      <img src={img} alt={name}/>
+    </div>
+  );
 }
 
 class Viewpoint extends Component {

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,0 +1,31 @@
+import conf from './config.json';
+
+let portfolio = conf.user;
+
+/*
+ * Get the "prop" config from config.json
+ * It is either:
+ * - customization[prop] for the current portfolio
+ * - default[prop] if there is no custom conf
+ * - the given "def" object if there is no default conf
+ */
+const getConfig = (prop, def) => {
+    if (conf.default && conf.default[prop]) {
+        Object.keys(conf.default[prop]).forEach(key => {
+            def[key] = conf.default[prop][key];
+        });
+    }
+
+    if (conf.customization && conf.customization[portfolio]) {
+        let custom = conf.customization[portfolio];
+        if (custom[prop]) {
+            Object.keys(custom[prop]).forEach(key => {
+                def[key] = custom[prop][key];
+            });
+        }
+    }
+    return def;
+}
+
+export default getConfig;
+

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -278,3 +278,17 @@
 
 .wrap:hover button{display: inherit;margin-right: 10px;z-index: 999}
 .wrap button{display:none;}
+
+.Article {
+  border-bottom: 1px solid #DDD;
+  color: black;
+  display: block;
+  margin: 1em;
+  text-align: left;
+  width: 100%;
+}
+
+.ArticleTitle {
+  font-weight: bold;
+}
+


### PR DESCRIPTION
## Content

This PR defines two display modes for the item lists (home page) and the item pages. The default mode, `picture`, is the one used by most portfolios. The new one, `article`, is oriented towards text-based portfolios like the one our team worked with (scientific publications).

See #109 for more useful details for developers.

Sample `config.json` for the `open-access` project:

```json
{
  "user": "open-access",
  "services": [
    "http://argos2.hypertopic.org",
    "http://steatite.hypertopic.org"
  ],
  "customization": {
    "open-access": {
      "listView": {
        "mode": "article",
        "name": "Title",
        "props": ["Year", "Authors"]
      },
      "itemView": {
        "mode": "article",
        "name": "Title",
        "text": "Abstract",
        "linkTo": "Offprint",
        "hiddenProps": ["topic", "Abstract", "Offprint"]
      }
    }
  }
}
```

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [x] corresponds to a contribution that should be notified to users,
    - [x] does not generate new errors or warnings at compile or test time,
    - [x] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [x] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `TEST` when it concerns an acceptance test,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [x] be followed by a colon (`:`) with one space after and no space before,
    - [x] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [x] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [x] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [x] related to this very contribution (feature, fix...),
    - [x] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [x] without any typo in variable, class or function names,
    - [x] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
