### PR TITLE
FEATURE: Lazy load

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react": "^16.4.0",
     "react-autosuggest": "^9.3.4",
     "react-dom": "^16.4.0",
+    "react-lazyload": "^2.3.0",
     "react-router-dom": "^4.1.1",
     "react-ui-tree-porphyry": "^1.0.3",
     "sort-by": "^1.2.0"

--- a/src/components/Corpora/Corpora.jsx
+++ b/src/components/Corpora/Corpora.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import getConfig from '../../config/config.js';
+import LazyLoad from "react-lazyload";
 
 // Get the configured list display mode
 let listView = getConfig('listView', {
@@ -15,7 +16,7 @@ class Corpora extends Component {
     let items = this._getItems();
     let count = this.props.items.length;
     let total = this.props.from;
-    return(
+    return (
       <div className="col-md-8 p-4">
         <div className="Subject">
           <h2 className="h4 font-weight-bold text-center">
@@ -32,8 +33,8 @@ class Corpora extends Component {
 
   _getItems() {
     return this.props.items.map(item =>
-        <Item key={item.id} item={item}
-          id={item.corpus+'/'+item.id} />
+      <Item key={item.id} item={item}
+        id={item.corpus + '/' + item.id} />
     );
   }
 
@@ -41,12 +42,12 @@ class Corpora extends Component {
 
 function Item(props) {
   switch (listView.mode) {
-  case 'article':
-    return Article(props.item);
-  case 'picture':
-    return Picture(props.item);
-  default:
-    return Picture(props.item);
+    case 'article':
+      return Article(props.item);
+    case 'picture':
+      return Picture(props.item);
+    default:
+      return Picture(props.item);
   }
 }
 
@@ -79,7 +80,9 @@ function Picture(item) {
   return (
     <div className="Item">
       <Link to={uri}>
-        <img src={img} alt={name}/>
+        <LazyLoad once throttle={200} height={100}>
+          <img src={img} alt={name} />
+        </LazyLoad>
       </Link>
       <div className="text-center">{name}</div>
     </div>


### PR DESCRIPTION
## Content

Load thumbnails in portfolio  by the time user scrolls mouse to.

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [x] corresponds to a contribution that should be notified to users,
    - [x] does not generate new errors or warnings at compile or test time,
    - [x] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [x] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `TEST` when it concerns an acceptance test,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [x] be followed by a colon (`:`) with one space after and no space before,
    - [x] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [x] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [x] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [x] related to this very contribution (feature, fix...),
    - [x] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [x] without any typo in variable, class or function names,
    - [x] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
