### PR TITLE
TEST: rename category function test

### DIFF
--- a/features/rename_category.feature
+++ b/features/rename_category.feature
@@ -1,0 +1,15 @@
+#language: fr
+
+Fonctionnalité: Renommer une catégorie
+
+Contexte:
+  Soit la page "Modification du point de vue" rattaché au point de vue "Histoire de l'art"
+  Soit la catégorie "Datation" rattaché au point de vue "Histoire de l'art"
+
+Scénario: Renommer la catégorie "Artiste" en "Artistes"
+  Soit "Modification du point de vue" la page ouverte
+  Et l'utilisateur est connecté avec le mot de passe
+  Et le point de vue "Histoire de l'art" est développé
+  Quand la catégorie "Datation" est modifiée en "Datage"
+  Alors la catégorie "Datation" n'est plus affiché
+  Et la catégorie "Datage" est affiché

--- a/features/step_definitions/rename_category.rb
+++ b/features/step_definitions/rename_category.rb
@@ -1,0 +1,49 @@
+require 'capybara/cucumber'
+require 'selenium/webdriver'
+
+Capybara.run_server = false
+Capybara.default_driver = :selenium_chrome_headless
+Capybara.app_host = "http://localhost:3000"
+Capybara.default_max_wait_time = 10
+Capybara.exact = true
+
+Soit("la page {string} rattaché au point de vue {string}") do |string, string2|
+  # On server side
+end
+
+Soit("la catégorie {string} rattaché au point de vue {string}") do |string, string2|
+  # On server side
+end
+
+Soit("{string} la page ouverte") do |titlePage|
+  visit "/viewpoint/a76306e4f17ed4f79e7e481eb9a1bd06"
+
+  expect(find("h2.h4")).to have_content(titlePage)
+end
+
+Soit(/^l'utilisateur est connecté avec le mot de passe$/) do
+  click_on('Se connecter...')
+  fill_in("nom d'utilisateur", with: "alice")
+  fill_in("mot de passe", with: "whiterabbit")
+
+  click_on('Se connecter')
+end
+
+Soit("le point de vue {string} est développé") do |viewpoint|
+  expect(find('.Outliner li.open', match: :first)).to have_content(viewpoint)
+
+end
+
+Quand("la catégorie {string} est modifiée en {string}") do |oldCategory, newCategory|
+  find("span.node", :text => oldCategory).double_click
+  find('input[value="' << oldCategory << '"]').set(newCategory)
+  find("h2").double_click
+end
+
+Alors("la catégorie {string} n'est plus affiché") do |viewpoint|
+  expect(page).not_to have_content(viewpoint)
+end
+
+Alors("la catégorie {string} est affiché") do |viewpoint|
+  expect(find("span.node", exact_text: viewpoint)).to have_content(viewpoint)
+end

--- a/features/step_definitions/rename_category.rb
+++ b/features/step_definitions/rename_category.rb
@@ -17,21 +17,18 @@ end
 
 Soit("{string} la page ouverte") do |titlePage|
   visit "/viewpoint/a76306e4f17ed4f79e7e481eb9a1bd06"
-
   expect(find("h2.h4")).to have_content(titlePage)
 end
 
-Soit(/^l'utilisateur est connecté avec le mot de passe$/) do
+Soit("l'utilisateur est connecté avec le mot de passe") do
   click_on('Se connecter...')
   fill_in("nom d'utilisateur", with: "alice")
   fill_in("mot de passe", with: "whiterabbit")
-
   click_on('Se connecter')
 end
 
 Soit("le point de vue {string} est développé") do |viewpoint|
   expect(find('.Outliner li.open', match: :first)).to have_content(viewpoint)
-
 end
 
 Quand("la catégorie {string} est modifiée en {string}") do |oldCategory, newCategory|


### PR DESCRIPTION
## Content

Add scenario: rename a category

Written by: @qdelcourte and @Double-Ramzi

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [x] corresponds to a contribution that should be notified to users,
    - [x] does not generate new errors or warnings at compile or test time,
    - [x] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [x] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `TEST` when it concerns an acceptance test,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [x] be followed by a colon (`:`) with one space after and no space before,
    - [x] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [x] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [x] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [x] related to this very contribution (feature, fix...),
    - [x] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [x] without any typo in variable, class or function names,
    - [x] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
