### PR TITLE
added a function:images of an artiste

### DIFF
--- a/features/images_appartient_rubrique.feature
+++ b/features/images_appartient_rubrique.feature
@@ -1,0 +1,22 @@
+#language: fr
+
+Fonctionnalité: Vérifier toutes les images appartiennent bien à une rubrique 
+
+Contexte:
+	Soit le point de vue "Histoire de l'art" rattaché au portfolio "vitraux"
+	Soit le corpus "Vitraux - Bénel" rattaché au portfolio "vitraux"
+	Soit le corpus "Vitraux - Recensement" rattaché au portfolio "vitraux"
+	
+	Soit la rubrique "Artiste" rattachée au point de vue "Histoire de l'art"
+	Soit la rubrique "Édouard-Amédée Didron" contenue dans la rubrique "Artiste"
+	Soit la rubrique "Hugot" contenue dans la rubrique "Artiste"
+	
+Scénario: quand la rubrique ne contient pas d'élement
+	Soit la rubrique "Artiste" sélectionnée et dévellopée 
+	Quand la rubrique "Hugot" est sélectionnée
+	Alors l'emplacement des items est vide
+	
+Scénario: quand la rubrique contient des élements	
+	Soit la rubrique "Artiste" sélectionnée et dévellopée 
+	Quand la rubrique "Édouard-Amédée Didron" est sélectionnée
+	Alors tous les items sont affichés et doivent appartenir à la rubrique "Édouard-Amédée Didron"

--- a/features/step_definitions/images_appartient_rubrique.rb
+++ b/features/step_definitions/images_appartient_rubrique.rb
@@ -1,0 +1,52 @@
+require 'capybara/cucumber'
+require 'selenium/webdriver'
+
+Capybara.run_server = false
+Capybara.default_driver = :selenium_chrome_headless
+Capybara.app_host = "http://localhost:3000"
+Capybara.default_max_wait_time = 10
+
+def getUUID2(itemName)
+  uuid = nil
+  case itemName
+    when "Hugot"
+      uuid = "8c4b184d5d6b0f40919f690f1f6ca7f5"
+    when "Édouard-Amédée Didron"
+      uuid = "8f57e7ea7d7b804a9fef571018e6384b"
+  end
+  return uuid
+end
+
+# Conditions
+
+Soit("la rubrique {string} rattaché au point de vue {string}") do |topic3, topic1|
+  # On the remote servers
+  # topic3 is "Hugot"
+end
+
+
+Soit("la rubrique {string} sélectionnée et dévellopée") do |topic1|
+	visit "/"
+end
+
+Quand("la rubrique {string} est sélectionnée") do |topic3|
+	visit "/?t=#{getUUID2(topic3)}"
+	#je veux utiliser la fonction getUUID, mais il retourne nil. Donc je donne une variable fixe pour tester.
+end
+
+
+Alors("l'emplacement des items est vide") do
+  expect(page).not_to have_selector('.Item')
+end
+
+Alors("tous les items sont affichés et doivent appartenir à la rubrique {string}") do |topic3|
+  links =[]
+  all('.Item').each{
+      |a| links += [a.find('a')[:href]]
+  }
+  for link in links
+      visit link
+      expect(page).to have_content topic3
+      end
+end
+


### PR DESCRIPTION
## Content

Writen by DU Qiaoqian && Guillaume GILLES. We added a function for looking for the pictures of an artiste.

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [x] corresponds to a contribution that should be notified to users,
    - [x] does not generate new errors or warnings at compile or test time,
    - [x] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [x] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `TEST` when it concerns an acceptance test,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [x] be followed by a colon (`:`) with one space after and no space before,
    - [x] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [x] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [x] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [x] related to this very contribution (feature, fix...),
    - [x] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [x] without any typo in variable, class or function names,
    - [x] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
