### PR TITLE
Ajout du scénario et du test de création de point de vue

### DIFF
--- a/features/new_point_de_vue.feature
+++ b/features/new_point_de_vue.feature
@@ -1,0 +1,18 @@
+#language: fr
+
+Fonctionnalité: Créer un nouveau point de vue
+
+Contexte:
+  Soit le point de vue "Histoire de l'art" rattaché au portfolio "vitraux"
+  Soit le point de vue "Histoire des religions" rattaché au portfolio "vitraux"
+
+Scénario:
+
+  Soit "vitraux" le portfolio spécifié dans la configuration
+  Soit "vitraux" le portfolio ouvert
+  Soit l'utilisateur est connecté
+  Soit l'utilisateur est sur la page de création de nouveau point de vue
+
+  Quand un utilisateur crée un nouveau point de vu nommé "Mon nouveau point de vue"
+
+  Alors le point de vue "Mon nouveau point de vue" est ajouté au portfolio "vitraux"

--- a/features/step_definitions/portfolio.rb
+++ b/features/step_definitions/portfolio.rb
@@ -1,11 +1,10 @@
 require 'capybara/cucumber'
-require 'capybara/cuprite'
+require 'selenium/webdriver'
 
 Capybara.run_server = false
-Capybara.default_driver = :cuprite
-Capybara.javascript_driver = :cuprite
+Capybara.default_driver = :selenium_chrome_headless
 Capybara.app_host = "http://localhost:3000"
-Capybara.default_max_wait_time = 10
+Capybara.default_max_wait_time = 30
 
 def getUUID(itemName)
   uuid = nil
@@ -92,6 +91,16 @@ Soit("la liste des rubriques sélectionnées est vide") do
   visit "/"
 end
 
+Soit ("l'utilisateur est sur la page de création de nouveau point de vue") do
+  click_on("Nouveau point de vue")
+end
+
+Soit ("l'utilisateur est connecté") do
+  click_link('Se connecter...')
+  fill_in("nom d'utilisateur", with: 'alice')
+  fill_in("mot de passe", with: 'whiterabbit')
+  click_on("Se connecter")
+end
 # Events
 
 Quand("un visiteur ouvre la page d'accueil du site") do
@@ -108,6 +117,11 @@ end
 
 Quand("on choisit l'item {string}") do |item|
   click_on item
+end
+
+Quand ("un utilisateur crée un nouveau point de vu nommé {string}") do |viewpoint|
+  fill_in('newTitle' , with:  viewpoint)
+  find(:xpath, ".//button[contains(@class,'add')]").click
 end
 
 # Outcomes
@@ -140,3 +154,6 @@ Alors ("l'item {string} n'est pas affiché") do |item|
   expect(page).not_to have_content item
 end
 
+Alors ("le point de vue {string} est ajouté au portfolio {string}") do |viewpoint, portfolio|
+  expect(page).to have_content viewpoint
+end


### PR DESCRIPTION
Ajout du scénario de création de point de vue, et modification de portfolio.rb pour ajouter les étapes de résolution du test

## Content
Valentin Guilloux et moi même avons mis au point ce scénario et le test qui lui correspont

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [ ] corresponds to a contribution that should be notified to users,
    - [ ] does not generate new errors or warnings at compile or test time,
    - [ ] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [ ] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `TEST` when it concerns an acceptance test,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [ ] be followed by a colon (`:`) with one space after and no space before,
    - [ ] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [ ] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [ ] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [ ] related to this very contribution (feature, fix...),
    - [ ] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [ ] without any typo in variable, class or function names,
    - [ ] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
