### PR TITLE
TEST: Describe an item with attributes

### DIFF
--- a/features/item_edit.feature
+++ b/features/item_edit.feature
@@ -1,0 +1,19 @@
+#language: fr
+#Timothée BAYART
+#Taher KAMOUN
+
+Fonctionnalité: Décrire un item à l'aide d'attributs
+
+Contexte:
+
+    Soit le point de vue "Histoire de l'art" rattaché au portfolio "vitraux"
+    Et l'item "SU 006" existant
+    Et l'attribut "license" n'existant pas dans la liste des attributs de l'item "SU 006"
+    Et l'utilisateur "Alice" connecté avec le mot de passe "whiterabbit"
+
+Scénario:
+
+    Soit "vitraux" le portfolio ouvert
+    Et "SU 006" l'item affiché
+    Quand on ajoute un attribut "license" et la valeur "CC-BY"
+    Alors la valeur de l'attribut "license" est "CC-BY"

--- a/features/step_definitions/item.rb
+++ b/features/step_definitions/item.rb
@@ -9,11 +9,30 @@ Capybara.default_max_wait_time = 10
 
 # Conditions
 
+Soit("l'item {string} existant") do |item|
+  # On the remote servers
+end
+
+Soit("l'attribut {string} n'existant pas dans la liste des attributs de l'item {string}") do |attribut, item|
+  # On the remote servers
+end
+
 Soit("{string} l'item affiché") do |item|
   click_on item
 end
 
 # Events
+
+Quand("on ajoute un attribut {string} et la valeur {string}") do |attribut, value|
+
+  find_button('Ajouter un attribut').click
+
+  fill_in 'key', with: attribut
+
+  fill_in 'value', with: value
+
+  find_button('Valider').click
+end
 
 Quand("on choisit la rubrique {string}") do |topic|
   click_on topic

--- a/features/step_definitions/portfolio.rb
+++ b/features/step_definitions/portfolio.rb
@@ -24,6 +24,17 @@ end
 
 # Conditions
 
+Soit("l'utilisateur {string} connecté avec le mot de passe {string}") do |username, password|
+  # On connecte l'utilisateur (/!\ malgré nos recherches, ces lignes ne fonctionnent pas...)
+  click_link('Se connecter...')
+  find("input[placeholder='nom d\'utilisateur']").set username
+  find("input[placeholder='mot de passe']").set password
+  find("input[value='Se connecter']").click
+
+  #Si l'utilisateur est connecté, son username est affiché sur la page
+  expect(page).to have_content(username)
+end
+
 Soit("le point de vue {string} rattaché au portfolio {string}") do |viewpoint, portfolio|
   # On the remote servers
 end


### PR DESCRIPTION
Binôme Timothée BAYART & Taher KAMOUN

Ajout du scénario et du test d'édition d'un item (ajout d'un nouvel attribut).

Une étape du test consiste en la connexion d'un utilisateur. Malgré nos recherches nous ne sommes pas parvenus à réaliser cette étape (nous avons quand même ajouté les instructions qui nous paraissent bonnes malgré qu'elles ne fonctionnent pas).
La dernière étape nécessitant également la connexion (pour vérifier que l'attribut a bien été ajouté), le test de cette étape échoue.

Hormis cela les autres étapes du test fonctionnent.
