### PR TITLE
FEATURE: Implement listing, adding and removing resources from an item.

### DIFF
--- a/features/resource_add.feature
+++ b/features/resource_add.feature
@@ -1,0 +1,15 @@
+#language: fr
+
+Fonctionnalité: Ajouter une ressource à un item (en tant que fichier)
+
+Contexte:
+  Soit l'item "1997_6-9_23-ex_ECU_R_C" rattaché à la rubrique "Lauréats"
+  Soit la rubrique "Lauréats" rattachée au point de vue "Concours"
+  Soit le point de vue "Concours" rattaché au portfolio "dessins"
+
+Scénario:
+  Soit "dessins" le portfolio ouvert
+  Soit l'utilisateur connecté
+  Soit  "1997_6-9_23-ex_ECU_R_C" l'item affiché
+  Quand on ajoute une ressource "test.txt" à un item
+  Alors une des ressources de l'item est "test.txt"

--- a/features/resource_consult.feature
+++ b/features/resource_consult.feature
@@ -1,0 +1,13 @@
+#language: fr
+
+Fonctionnalité: Consulter les ressources associées à un item
+
+Contexte:
+  Soit l'item "1997_6-9_23-ex_ECU_R_C" rattaché à la rubrique "Lauréats"
+  Soit la rubrique "Lauréats" rattachée au point de vue "Concours"
+  Soit le point de vue "Concours" rattaché au portfolio "dessins"
+
+Scénario:
+  Soit "dessins" le portfolio ouvert
+  Quand on choisit l'item "1997_6-9_23-ex_ECU_R_C"
+  Alors une des ressources de l'item est "description.txt"

--- a/features/samples/test.txt
+++ b/features/samples/test.txt
@@ -1,0 +1,1 @@
+Ceci est un fichier de test qui sera ajouté à un item en tant que ressource.

--- a/features/step_definitions/item.rb
+++ b/features/step_definitions/item.rb
@@ -9,6 +9,13 @@ Capybara.default_max_wait_time = 10
 
 # Conditions
 
+Soit("l'utilisateur connecté") do
+  find_link(href: "#login").click
+  fill_in "nom d'utilisateur", with: "alice"
+  fill_in "mot de passe", with: "whiterabbit"
+  click_on "Se connecter"
+end
+
 Soit("{string} l'item affiché") do |item|
   click_on item
 end
@@ -17,6 +24,10 @@ end
 
 Quand("on choisit la rubrique {string}") do |topic|
   click_on topic
+end
+
+Quand("on ajoute une ressource {string} à un item") do |string|
+  attach_file("Ajouter une ressource...", "features/samples/#{string}", visible: false)
 end
 
 # Outcomes
@@ -34,3 +45,6 @@ Alors("une des rubriques de l'item est {string}") do |topic|
   expect(page).to have_content(topic)
 end
 
+Alors("une des ressources de l'item est {string}") do |resource|
+  expect(page).to have_content(resource)
+end

--- a/src/config/config.json
+++ b/src/config/config.json
@@ -1,5 +1,5 @@
 {
-  "user": "vitraux",
+  "user": "dessins",
   "services": [
     "http://argos2.test.hypertopic.org",
     "http://steatite.hypertopic.org"

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -142,12 +142,12 @@ h1 a, h1 a:hover {
   color: black;
 }
 
-.Attributes {
+.Attributes, .Resources {
   display: table;
   width: 100%;
 }
 
-.Attribute {
+.Attribute, .Resource {
   display: table-row;
 }
 
@@ -186,6 +186,20 @@ h1 a, h1 a:hover {
 div:hover > .buttons > button,
 div:hover > .DeleteButton,
 div:hover > .EditButton {
+  visibility: visible;
+}
+
+.Resource > .resourceName {
+  display: table-cell;
+  padding: 5px;
+  text-align: left;
+}
+
+.TopicPath > .DeleteTopicButton, .Attribute > .DeleteTopicButton, .Resource > .buttons {
+  visibility: hidden;
+}
+
+.TopicPath:hover > .DeleteTopicButton, .Attribute:hover > .DeleteTopicButton, .Resource:hover > .buttons {
   visibility: visible;
 }
 


### PR DESCRIPTION
## Content

This implements the ability for users to list, submit and delete resources (which can be text or binary files).

The "add a resource" test doesn't work as expected, as the `attach_file()` function is causing Chrome to crash.

```text
# language: fr
Fonctionnalité: Ajouter une ressource à un item (en tant que fichier)

  Contexte:                                                                # features/resource_add.feature:5
    Soit l'item "1997_6-9_23-ex_ECU_R_C" rattaché à la rubrique "Lauréats" # features/step_definitions/portfolio.rb:47
    Soit la rubrique "Lauréats" rattachée au point de vue "Concours"       # features/step_definitions/portfolio.rb:43
    Soit le point de vue "Concours" rattaché au portfolio "dessins"        # features/step_definitions/portfolio.rb:27

  Scénario:                                            # features/resource_add.feature:10
    Soit "dessins" le portfolio ouvert                 # features/step_definitions/portfolio.rb:62
    Soit l'utilisateur connecté                        # features/step_definitions/item.rb:19
    Soit "1997_6-9_23-ex_ECU_R_C" l'item affiché       # features/step_definitions/item.rb:26
    Quand on ajoute une ressource "test.txt" à un item # features/step_definitions/item.rb:36
    Alors une des ressources de l'item est "test.txt"  # features/step_definitions/item.rb:55
      Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the Cuprite :timeout option to a higher value might help. (Capybara::Cuprite::TimeoutError)
      ./features/step_definitions/item.rb:56:in `"une des ressources de l'item est {string}"'
      features/resource_add.feature:15:in `Alors une des ressources de l'item est "test.txt"'

Failing Scenarios:
cucumber features/resource_add.feature:10 # Scénario: 

1 scenario (1 failed)
8 steps (1 failed, 7 passed)
0m14.756s
```

To test this, run Chrome in non-headless mode by adding the following at the top of `features/step_definitions/item.rb`:

```ruby
Capybara.register_driver :cuprite do |app|
  Capybara::Cuprite::Driver.new(app, {
    headless: false,
    slowmo: 0.06,
  })
end
```

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [x] corresponds to a contribution that should be notified to users,
    - [x] does not generate new errors or warnings at compile or test time,
    - [x] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [x] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `TEST` when it concerns an acceptance test,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [x] be followed by a colon (`:`) with one space after and no space before,
    - [x] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [x] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [x] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [x] related to this very contribution (feature, fix...),
    - [x] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [x] without any typo in variable, class or function names,
    - [x] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).