### PR TITLE
Feature #208 - Open a Resource

### DIFF
--- a/features/attribute_set.feature
+++ b/features/attribute_set.feature
@@ -15,3 +15,4 @@ Scénario: ayant pour valeur des URI
   Et l'utilisateur "alice" connecté
   Quand l'utilisateur indique "https://www.aube-champagne.com/fr/poi/hotel-de-vauluisant-musee-de-vauluisant/#cdt-information" comme valeur de l'attribut "visite"
   Alors la valeur de l'attribut "visite" est "https://www.aube-champagne.com/fr/poi/hotel-de-vauluisant-musee-de-vauluisant/#cdt-information"
+  Et "https://www.aube-champagne.com/fr/poi/hotel-de-vauluisant-musee-de-vauluisant/#cdt-information" mène à une page intitulée "Musée de Vauluisant"

--- a/features/step_definitions/outcome.rb
+++ b/features/step_definitions/outcome.rb
@@ -34,3 +34,8 @@ end
 Alors("une des rubriques de l'item est {string}") do |topic|
   expect(page).to have_css '.Topic', text: topic
 end
+
+Alors("{string} mène à une page intitulée {string}") do |uri, title|
+  click_link uri
+  expect(page.title).to have_content title
+end

--- a/src/components/itemPage/Attribute.jsx
+++ b/src/components/itemPage/Attribute.jsx
@@ -89,6 +89,11 @@ function AttributeValue(props) {
       />
     </div>
   );
+  if (props.value && props.value.startsWith('http')) return (
+    <a href={props.value} className="Value">
+      {props.value}
+    </a>
+  );
   return (
     <div className="Value">
       {props.value}


### PR DESCRIPTION
## Content

FEATURE: #208 - Open a resource 
Added a check to control if the attribute starts with "http", in which case the returned value will be nested in a "<a/>" tag to make the link clickable.

Closes #208 

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [X] corresponds to a contribution that should be notified to users,
    - [X] does not generate new errors or warnings at compile or test time,
    - [X] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [X] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `TEST` when it concerns an acceptance test,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [X] be followed by a colon (`:`) with one space after and no space before,
    - [X] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [X] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [X] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [X] related to this very contribution (feature, fix...),
    - [X] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [X] without any typo in variable, class or function names,
    - [X] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
