### PR TITLE
Feature 208

### DIFF
--- a/features/attribute_set.feature
+++ b/features/attribute_set.feature
@@ -15,3 +15,4 @@ Scénario: ayant pour valeur des URI
   Et l'utilisateur "alice" connecté
   Quand l'utilisateur indique "https://www.aube-champagne.com/fr/poi/hotel-de-vauluisant-musee-de-vauluisant/#cdt-information" comme valeur de l'attribut "visite"
   Alors la valeur de l'attribut "visite" est "https://www.aube-champagne.com/fr/poi/hotel-de-vauluisant-musee-de-vauluisant/#cdt-information"
+  Et "https://www.aube-champagne.com/fr/poi/hotel-de-vauluisant-musee-de-vauluisant/#cdt-information" mène à une page intitulée "Musée de Vauluisant"

--- a/features/step_definitions/outcome.rb
+++ b/features/step_definitions/outcome.rb
@@ -34,3 +34,8 @@ end
 Alors("une des rubriques de l'item est {string}") do |topic|
   expect(page).to have_css '.Topic', text: topic
 end
+
+Alors("{string} mène à une page intitulée {string}") do |uri, title|
+  click_link uri
+  expect(page.title).to have_content title
+end

--- a/src/components/itemPage/Attribute.jsx
+++ b/src/components/itemPage/Attribute.jsx
@@ -89,8 +89,13 @@ function AttributeValue(props) {
       />
     </div>
   );
+  //l'ajout pour le lien cliquable
+  if {props.value.substring(0, 4)=="http"}
+    return (<a className="Value" href = {props.value}>{props.value}</a>);
+  }
   return (
     <div className="Value">
+
       {props.value}
     </div>
   );

--- a/src/components/itemPage/Attribute.jsx
+++ b/src/components/itemPage/Attribute.jsx
@@ -90,7 +90,7 @@ function AttributeValue(props) {
     </div>
   );
   //l'ajout pour le lien cliquable
-  if {props.value.substring(0, 4)=="http"}
+  if (props.value.substring(0, 4)=="http") {
     return (<a className="Value" href = {props.value}>{props.value}</a>);
   }
   return (


### PR DESCRIPTION
## Content

Contribution de test pour implémenter la feature 208

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [x] corresponds to a contribution that should be notified to users,
    - [x] does not generate new errors or warnings at compile or test time,
    - [x] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [x] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `TEST` when it concerns an acceptance test,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [x] be followed by a colon (`:`) with one space after and no space before,
    - [x] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [x] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [x] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [x] related to this very contribution (feature, fix...),
    - [x] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [x] without any typo in variable, class or function names,
    - [ xcorrectly indented (spaces rather than tabs, same number of characters as in the rest of the file).
