### PR TITLE
FEATURE: Streamed long polling instead of active polling (closes #52)

### DIFF
--- a/src/components/portfolioPage/Portfolio.jsx
+++ b/src/components/portfolioPage/Portfolio.jsx
@@ -55,9 +55,24 @@ class Portfolio extends Component {
     );
   }
 
+  _get_int_update_seq(update_seq){
+    return parseInt(update_seq.slice(0,update_seq.indexOf("-")));
+  }
+
+  async _get_latest_update_seq() {
+    const response = await fetch('http://if05.local');
+    var myjson = await response.json();
+    return myjson.update_seq;
+  }
+
   componentDidMount() {
     let start=new Date().getTime();
     var self=this;
+
+    (async () => {
+      this.update_seq = await this._get_latest_update_seq()
+    })();
+
     this._fetchAll().then(() => {
       let end=new Date().getTime();
       let elapsedTime=end-start;
@@ -66,8 +81,13 @@ class Portfolio extends Component {
       let intervalTime=Math.max(10000,elapsedTime*5);
       console.log("reload every ",intervalTime);
       self._timer = setInterval(
-        () => {
-          self._fetchAll();
+        async () => {
+          var latest_seq = await this._get_latest_update_seq();
+
+          if(self._get_int_update_seq(self.update_seq)<self._get_int_update_seq(latest_seq)){
+            self.update_seq = latest_seq;
+            self._fetchAll();
+          }
         },
         intervalTime
       );


### PR DESCRIPTION
## Content

Porphyry ne recharge la page du portfolio que s'il y a eu des modifications dans Argos. 
Pour la page des items, un eventsource attend les modifications dans Argos, ce qui permet de faire une mise à jour des données (attribut et point de vue) en temps réelle.

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [x] corresponds to a contribution that should be notified to users,
    - [x] does not generate new errors or warnings at compile or test time,
    - [x] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [x] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `TEST` when it concerns an acceptance test,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [x] be followed by a colon (`:`) with one space after and no space before,
    - [x] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [x] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [x] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [x] related to this very contribution (feature, fix...),
    - [x] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [x] without any typo in variable, class or function names,
    - [x] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
