### PR TITLE
REFACTORING : Streamed long polling instead of active polling (#52)

### DIFF
--- a/src/components/itemPage/Viewpoint.jsx
+++ b/src/components/itemPage/Viewpoint.jsx
@@ -12,10 +12,19 @@ class Viewpoint extends React.Component {
   constructor(props) {
     super();
     this.state = {
+      update_seq: props.update_seq,
       topics: {},
       topicInputvalue: '',
       currentSelection: '',
     };
+  }
+
+  componentWillReceiveProps({update_seq}) {
+    if (update_seq){
+      this._fetchViewpoint().then(() => {
+        this.setState({...this.state, update_seq});
+      })
+    }
   }
 
   onTopicInputFocus = (event) => {
@@ -150,6 +159,7 @@ class Viewpoint extends React.Component {
         id={t.id}
         topics={this.state.topics}
         removeTopic={() => this.props.removeTopic(t)}
+        update_seq={this.state.update_seq}
       />
     ));
   }
@@ -160,7 +170,7 @@ class Viewpoint extends React.Component {
 
   async _fetchViewpoint() {
     let hypertopic = new Hypertopic((await conf).services);
-    hypertopic.getView(`/viewpoint/${this.props.id}`).then((data) => {
+    return hypertopic.getView(`/viewpoint/${this.props.id}`).then((data) => {
       let viewpoint = data[this.props.id];
       let name = viewpoint.name;
       let topics = viewpoint;


### PR DESCRIPTION
## Content

Porphyry ne recharge la page du portfolio que s'il y a eu des modifications dans Argos. 
Pour la page des items, un eventsource attend les modifications dans Argos, ce qui permet de faire une mise à jour des données (attribut et point de vue) en temps réelle.

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [x] corresponds to a contribution that should be notified to users,
    - [x] does not generate new errors or warnings at compile or test time,
    - [x] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [x] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `TEST` when it concerns an acceptance test,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [x] be followed by a colon (`:`) with one space after and no space before,
    - [x] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [x] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [x] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [x] related to this very contribution (feature, fix...),
    - [x] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [x] without any typo in variable, class or function names,
    - [x] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
