### PR TITLE
FEATURE: Look at thumbnails of items with the same name (see #66)

### DIFF
--- a/features/check_same_name_items.feature
+++ b/features/check_same_name_items.feature
@@ -1,0 +1,12 @@
+#language: fr
+
+Fonctionnalité: Voir les vignettes d'items du même nom
+
+Scénario:
+
+Soit "KER 2733" l'item affiché
+Et l'attribut "view" a pour valeur "face"
+Et "KER 2733" un des items affichés
+Quand l'utilisateur choisit l'item "KER 2733" dans le bloc Items ayant le même nom
+Alors l'item "KER 2733" est affiché
+Et la valeur de l'attribut "view" est "côté"

--- a/src/components/itemPage/SameNameBlock.jsx
+++ b/src/components/itemPage/SameNameBlock.jsx
@@ -1,0 +1,97 @@
+import React, { Component } from 'react';
+import Hypertopic from 'hypertopic';
+import conf from '../../config.js';
+
+class SameNameBlock extends Component {
+
+  constructor() {
+    super();
+    this.state = {
+      sameNameItemsList: []
+    };
+  }
+
+  render() {
+    let items = this._getItems();
+    if (this.state.sameNameItemsList.length > 0) {
+      return (
+        <div className="Description">
+          <h2 className="h4 font-weight-bold text-center">Items ayant le même nom</h2>
+          <div className="Items m-3">
+            {items}
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div className="p-2">
+      </div>
+    );
+  }
+
+  _fetchSameNameItems = async () => {
+    let SETTINGS = await conf;
+    let hypertopic = new Hypertopic(SETTINGS.services);
+    return hypertopic.getView(`/user/${SETTINGS.user}`)
+      .then(data => {
+        let user = data[SETTINGS.user] || {};
+        user = {
+          corpus: user.corpus || []
+        };
+        return user;
+      })
+      .then(x =>
+        x.corpus.map(y => `/corpus/${y.id}`)
+      )
+      .then(hypertopic.getView)
+      .then((data) => {
+        let itemName = this.props.item.name.toString();
+        var sameNameItemsList = [];
+        for (let corpusID in data) {
+          let currentCorpus = data[corpusID];
+          for (let itemID in currentCorpus) {
+            let currentItem = currentCorpus[itemID];
+            if (typeof(currentItem) === 'object') {
+              currentItem.id = itemID;
+              currentItem.corpus = corpusID;
+              if (Array.isArray(currentItem.name)) {
+                let currentItemName = currentItem.name.toString();
+                if (currentItemName === itemName && currentItemName !== undefined && currentItem.id !== this.props.ID && currentItem.thumbnail !== undefined) {
+                  sameNameItemsList.push(currentItem);
+                }
+              }
+            }
+          }
+        }
+        this.setState({sameNameItemsList});
+      });
+
+  }
+
+  componentDidMount() {
+    this._fetchSameNameItems();
+  }
+
+  _getItems() {
+    return this.state.sameNameItemsList.map(item =>
+      <Item key={item.id} item={item} />
+    );
+  }
+
+}
+
+function Item(props) {
+  let uri = `/item/${props.item.corpus}/${props.item.id}`;
+  let thumbnail = props.item.thumbnail;
+  let name = [props.item.name].join(', '); //Name can be an array
+  if (thumbnail) return (
+    <div className="Item">
+      <a href={uri}>
+        <img src={thumbnail} alt={name}/>
+      </a>
+    </div>
+  );
+
+}
+
+export default SameNameBlock;


### PR DESCRIPTION
## Content

With this feature, thumbnails of items which have the same name  with the consulted item will be seen in the page of this item. The user con also click on them to visit the associated page. We should notice that, because of the behaviour of this feature, one necessary condition is for an item to have a thumbnail. If not, it won't be visible in the same name items block.

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [ ] corresponds to a contribution that should be notified to users,
    - [ ] does not generate new errors or warnings at compile or test time,
    - [ ] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [x] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `TEST` when it concerns an acceptance test,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [x] be followed by a colon (`:`) with one space after and no space before,
    - [x] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [ ] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [ ] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [ ] related to this very contribution (feature, fix...),
    - [ ] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [ ] without any typo in variable, class or function names,
    - [ ] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
