### PR TITLE
TEST: Sort items according to the value of an attribute (see #38)

### DIFF
--- a/features/portfolio_sort.feature
+++ b/features/portfolio_sort.feature
@@ -1,0 +1,16 @@
+#language: fr
+
+Fonctionnalité: Trier les items du portfolio
+
+Scénario: Par la valeur de l'attribut spatial
+
+Soit "XIXe s." les rubriques sélectionnées
+Et la liste d'items est affichée dans cet ordre là
+  |SM 001 m|
+  |SM 001 n|
+  |SR 005|
+Quand l'utilisateur trie les items par la valeur de l'attribut "spatial"
+Alors la liste d'items est affichée dans cet ordre
+  |SR 005|
+  |SM 001 m|
+  |SM 001 n|

--- a/features/step_definitions/context.rb
+++ b/features/step_definitions/context.rb
@@ -57,3 +57,10 @@ Soit("l'attribut {string} a pour valeur {string}") do |attribute, value|
   expect(page).to have_content value
   expect(page).to have_content attribute
 end
+
+Soit("la liste d'items est affichée dans cet ordre là") do |table|
+  results = page.all('div.Item div').map do |div|
+    [div.text]
+  end
+  table.diff!(results)
+end

--- a/features/step_definitions/event.rb
+++ b/features/step_definitions/event.rb
@@ -55,3 +55,7 @@ Quand("l'utilisateur choisit l'item {string} dans le bloc Items ayant le même n
     click_on item
   end
 end
+
+Quand("l'utilisateur trie les items par la valeur de l'attribut {string}") do |attribut|
+  select attribut, from: "attribut"
+end

--- a/features/step_definitions/outcome.rb
+++ b/features/step_definitions/outcome.rb
@@ -39,3 +39,10 @@ Alors("{string} mène à une page intitulée {string}") do |uri, title|
   click_link uri
   expect(page.title).to have_content title
 end
+
+Alors("la liste d'items est affichée dans cet ordre") do |table|
+  results = page.all('div.Item div').map do |div|
+    [div.text]
+  end
+  table.diff!(results)
+end


### PR DESCRIPTION
Co-Authored-By: HONGXinY <xinying.hong@utt.fr>
Co-Authored-By: yiyi1998 <yiyi.chen@utt.fr>

## Content

Test de la fonctionnalité #38 
Une nouvelle version de test fonctionnel qui fait suite à [cette pull request](https://github.com/Hypertopic/Porphyry/pull/357). 

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [x] corresponds to a contribution that should be notified to users,
    - [x] does not generate new errors or warnings at compile or test time,
    - [x] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [x] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `TEST` when it concerns an acceptance test,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [x] be followed by a colon (`:`) with one space after and no space before,
    - [x] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [x] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [x] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [x] related to this very contribution (feature, fix...),
    - [x] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [x] without any typo in variable, class or function names,
    - [x] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
