### PR TITLE
TEST: OR and AND with negative selections. (see #366)

### DIFF
--- a/features/portfolio_browse.feature
+++ b/features/portfolio_browse.feature
@@ -66,3 +66,20 @@ Scénario: en remplaçant le ET par un OU
   Et l'item "SM 001 n" est caché
   Et l'item "SNZ 005" est caché
   Et l'item "SR 005" est caché
+
+Scénario: en sélectionnant négativement
+
+  Soit "Personnages|Récits" les rubriques sélectionnées négativement
+  Et "AXN 009" un des items affichés
+  Et "SMV 129" un des items affichés
+  Et "SNZ 009" un des items affichés
+  Et "SNZ 005" un des items cachés
+  Et "PSM 002" un des items cachés
+  Et "SM 001 m" un des items cachés
+  Quand l'utilisateur change l'opérateur entre la rubrique "Personnages" et la rubrique "Récits"
+  Et "AXN 009" un des items affichés
+  Et "SMV 129" un des items affichés
+  Et "SNZ 009" un des items affichés
+  Et "SNZ 005" un des items affichés
+  Et "PSM 002" un des items affichés
+  Et "SM 001 m" un des items affichés

--- a/features/portfolio_browse.feature
+++ b/features/portfolio_browse.feature
@@ -70,16 +70,8 @@ Scénario: en remplaçant le ET par un OU
 Scénario: en sélectionnant négativement
 
   Soit "Personnages|Récits" les rubriques sélectionnées négativement
-  Et "AXN 009" un des items affichés
-  Et "SMV 129" un des items affichés
-  Et "SNZ 009" un des items affichés
-  Et "SNZ 005" un des items cachés
-  Et "PSM 002" un des items cachés
   Et "SM 001 m" un des items cachés
+  Et "SR 005" un des items cachés
   Quand l'utilisateur change l'opérateur entre la rubrique "Personnages" et la rubrique "Récits"
-  Et "AXN 009" un des items affichés
-  Et "SMV 129" un des items affichés
-  Et "SNZ 009" un des items affichés
-  Et "SNZ 005" un des items affichés
-  Et "PSM 002" un des items affichés
-  Et "SM 001 m" un des items affichés
+  Alors "SM 001 m" un des items affichés
+  Et "SR 005" un des items affichés

--- a/features/step_definitions/context.rb
+++ b/features/step_definitions/context.rb
@@ -55,5 +55,6 @@ Soit("{string} les rubriques sélectionnées négativement") do |topics|
   visit '/'
   topics.split('|').each do |topic|
      click_on topic
+     click_on topic
   end
 end

--- a/features/step_definitions/context.rb
+++ b/features/step_definitions/context.rb
@@ -50,3 +50,10 @@ end
 Soit("la langue du navigateur est {string}") do |language|
   page.driver.add_headers("Accept-Language" => language)
 end
+
+Soit("{string} les rubriques sélectionnées négativement") do |topics|
+  visit '/'
+  topics.split('|').each do |topic|
+     click_on topic
+  end
+end


### PR DESCRIPTION
## Content

Please describe your contribution here...

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [ ] corresponds to a contribution that should be notified to users,
    - [ ] does not generate new errors or warnings at compile or test time,
    - [ ] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [x] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `TEST` when it concerns an acceptance test,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [x] be followed by a colon (`:`) with one space after and no space before,
    - [x] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [x] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [ ] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [x] related to this very contribution (feature, fix...),
    - [ ] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [x] without any typo in variable, class or function names,
    - [ ] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
