### PR TITLE
Fix 366

### DIFF
--- a/features/portfolio_search.feature
+++ b/features/portfolio_search.feature
@@ -11,3 +11,12 @@ Scénario: une valeur d'attribut
   Alors l'item "AXN 009" est affiché
   Mais l'item "SJ 001" est caché
 
+Scénario: un type d'attribut
+
+  Soit "vitraux" le portfolio ouvert
+  Et "AXN 009" un des items affichés
+  Et "PSM 002" un des items affichés
+  Quand l'utilisateur recherche "creator" puis choisit "creator : Denis Krieger"
+  Alors l'item "PSM 002" est affiché
+  Mais l'item "AXN 009" est caché
+

--- a/features/portfolio_search.feature
+++ b/features/portfolio_search.feature
@@ -20,3 +20,12 @@ Scénario: un type d'attribut
   Alors l'item "PSM 002" est affiché
   Mais l'item "AXN 009" est caché
 
+Scénario: une rubrique
+
+  Soit "vitraux" le portfolio ouvert
+  Et "SM 001 n" un des items affichés
+  Et "SM 008 g" un des items affichés
+  Quand l'utilisateur recherche "larcher" puis choisit "Artiste > Vincent-Larcher"
+  Alors l'item "SM 001 n" est affiché
+  Mais l'item "SM 008 g" est caché
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-dom": "^16.14.0",
         "react-geocode": "^0.2.2",
         "react-router-dom": "^5.2.0",
+        "voll": "^1.2.6",
         "yaml": "^1.10.0"
       },
       "devDependencies": {
@@ -26082,6 +26083,40 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
     },
+    "node_modules/voll": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/voll/-/voll-1.2.6.tgz",
+      "integrity": "sha512-j55wrBr79ayfhtAdbRvs3wq22z/B+uyX25QspjgQvOSBYfY8UaJ95YTeL/Xnb73RG0GOzZ+JQD49c3kcvKrEsg==",
+      "dependencies": {
+        "mem": "~8.0.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/voll/node_modules/mem": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-8.0.0.tgz",
+      "integrity": "sha512-qrcJOe6uD+EW8Wrci1Vdiua/15Xw3n/QnaNXE7varnB6InxSk7nu3/i5jfy3S6kWxr8WYJ6R1o0afMUtvorTsA==",
+      "dependencies": {
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/mem?sponsor=1"
+      }
+    },
+    "node_modules/voll/node_modules/mimic-fn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -49070,6 +49105,30 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
+    },
+    "voll": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/voll/-/voll-1.2.6.tgz",
+      "integrity": "sha512-j55wrBr79ayfhtAdbRvs3wq22z/B+uyX25QspjgQvOSBYfY8UaJ95YTeL/Xnb73RG0GOzZ+JQD49c3kcvKrEsg==",
+      "requires": {
+        "mem": "~8.0.0"
+      },
+      "dependencies": {
+        "mem": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-8.0.0.tgz",
+          "integrity": "sha512-qrcJOe6uD+EW8Wrci1Vdiua/15Xw3n/QnaNXE7varnB6InxSk7nu3/i5jfy3S6kWxr8WYJ6R1o0afMUtvorTsA==",
+          "requires": {
+            "map-age-cleaner": "^0.1.3",
+            "mimic-fn": "^3.1.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+          "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="
+        }
+      }
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^16.14.0",
     "react-geocode": "^0.2.2",
     "react-router-dom": "^5.2.0",
+    "voll": "^1.2.6",
     "yaml": "^1.10.0"
   },
   "devDependencies": {

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -1,0 +1,86 @@
+let switchPlace = (clause, criterion, toDelete, threeState) => {
+  let index;
+  if ((index = clause.selection.indexOf(criterion)) > -1) {
+    clause.selection.splice(index, 1);
+    if (!toDelete)
+      clause.exclusion.push(criterion);
+  } else if ((index = clause.exclusion.indexOf(criterion)) > -1) {
+    clause.exclusion.splice(index, 1);
+    if (!toDelete && !threeState)
+      clause.selection.push(criterion);
+  } else {
+    clause.selection.push(criterion);
+  }
+};
+
+export default class Selection {
+
+  constructor(query) {
+    let data = (query)
+      ? [{
+        type: 'intersection',
+        selection: [query],
+        exclusion: []
+      }]
+      : [];
+    this.selectionJSON = {type: 'intersection', data};
+  }
+
+  toJSON = () => JSON.stringify(this.selectionJSON);
+
+  toURI = () => `/?t=${this.toJSON()}`;
+
+  getSelected = () => this.selectionJSON.data.map(s => s.selection).flat();
+
+  getExcluded = () => this.selectionJSON.data.map(s => s.exclusion).flat();
+
+  isSelectedOrExcluded = (criterion) => {
+    if (this.getSelected().includes(criterion))
+      return 'Selected';
+    if (this.getExcluded().includes(criterion))
+      return 'Excluded';
+  }
+
+  setJSON = (json) => {
+    this.selectionJSON = JSON.parse(json);
+  }
+
+  toggleTopic = (topicID, viewpoint) => {
+    let clause = this.selectionJSON.data.find(s => {
+      let allTopics = [...s.selection, ...s.exclusion];
+      if (allTopics.length === 0 || viewpoint[allTopics[0]] === undefined) {
+        return false;
+      }
+      return (!viewpoint[allTopics[0]].hasOwnProperty('broader') && !viewpoint[topicID].hasOwnProperty('broader'))
+        || (viewpoint[allTopics[0]].hasOwnProperty('broader') && viewpoint[allTopics[0]].broader[0].id) === (viewpoint[topicID].hasOwnProperty('broader') && viewpoint[topicID].broader[0].id);
+    });
+    if (!clause) {
+      this.selectionJSON.data.push({type: 'intersection', selection: [topicID], exclusion: []});
+    } else {
+      switchPlace(clause, topicID, false, true);
+      if ([...clause.selection, ...clause.exclusion].length === 0)
+        this.selectionJSON.data.splice(this.selectionJSON.data.indexOf(clause), 1);
+    }
+  }
+
+  toggleCriterion = (criterion, toDelete) => {
+    let clause = this.selectionJSON.data.find(s => [...s.selection, ...s.exclusion].includes(criterion));
+    switchPlace(clause, criterion, toDelete);
+    if ([...clause.selection, ...clause.exclusion].length === 0)
+      this.selectionJSON.data.splice(this.selectionJSON.data.indexOf(clause), 1);
+  }
+
+  toggleOperator = (clause) => {
+    clause.type = (clause.type === 'intersection') ? 'union' : 'intersection';
+  }
+
+  getClauses = () => this.selectionJSON.data;
+
+  getMainClause = () => this.selectionJSON;
+
+  isEmpty = () => this.selectionJSON.data.length === 0;
+
+  getOperator = () => this.selectionJSON.type;
+
+}
+

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -1,3 +1,5 @@
+import parse from 'voll';
+
 let switchPlace = (clause, criterion, toDelete, threeState) => {
   let index;
   if ((index = clause.selection.indexOf(criterion)) > -1) {
@@ -12,6 +14,15 @@ let switchPlace = (clause, criterion, toDelete, threeState) => {
     clause.selection.push(criterion);
   }
 };
+
+let clauseToString = (x) => (
+  (x.data)
+    ? x.data.map((y) => `(${clauseToString(y)})`)
+    : [
+      ...x.selection.map((y) => `'${y}'`),
+      ...x.exclusion.map((y) => `NOT('${y}')`)
+    ]
+).join((x.type === 'intersection') ? ' AND ' : ' OR ');
 
 export default class Selection {
 
@@ -29,6 +40,10 @@ export default class Selection {
   toJSON = () => JSON.stringify(this.selectionJSON);
 
   toURI = () => `/?t=${this.toJSON()}`;
+
+  toBooleanString = () => clauseToString(this.selectionJSON);
+
+  toFilter = () => parse(this.toBooleanString());
 
   getSelected = () => this.selectionJSON.data.map(s => s.selection).flat();
 

--- a/src/components/itemPage/Attribute.jsx
+++ b/src/components/itemPage/Attribute.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { t } from '@lingui/macro';
 import { i18n } from '../../index.js';
+import Selection from '../../Selection.js';
 
 class Attribute extends React.Component {
 
@@ -100,7 +101,8 @@ function AttributeValue(props) {
       {props.value}
     </a>
   );
-  let uri = `../../?t={"type":"intersection","data":[{"type":"intersection","selection":["${props.name} : ${props.value}"],"exclusion":[]}]}`;
+  let criterion = `${props.name} : ${props.value}`;
+  let uri = `../..${(new Selection(criterion)).toURI()}`;
   return (
     <Link className="Value" to={uri}> {props.value} </Link>
   );

--- a/src/components/itemPage/TopicPath.jsx
+++ b/src/components/itemPage/TopicPath.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import Selection from '../../Selection.js';
 
 class TopicPath extends React.Component {
 
@@ -60,7 +61,7 @@ class TopicPath extends React.Component {
   _getTopics() {
     return this.state.path.map(t => {
       let name = t.name || '';
-      let uri = `../../?t={"type":"intersection","data":[{"type":"intersection","selection":["${t.id}"],"exclusion":[]}]}`;
+      let uri = `../..${(new Selection(t.id)).toURI()}`;
       return (
         <Link title={t.id} key={t.id} className="Topic" to={uri}>{name}</Link>
       );

--- a/src/components/portfolioPage/Button.jsx
+++ b/src/components/portfolioPage/Button.jsx
@@ -8,7 +8,7 @@ class Button extends Component {
     this.handleChangeState = this.handleChangeState.bind(this);
   }
   render() {
-    let union = (this.props.topics.type === 'union');
+    let union = (this.props.clause.type === 'union');
     return (<button className="badge badge-pill badge-secondary border-0 m-1 align-middle"
       title={union ? i18n._(t`Ou`) : i18n._(t`Et`)}
       onClick={this.handleChangeState}>  {union ? i18n._(t`Ou`) : i18n._(t`Et`)}</button>
@@ -16,7 +16,7 @@ class Button extends Component {
   }
 
   handleChangeState() {
-    this.props._changeUnionState(this.props.topics);
+    this.props._changeUnionState(this.props.clause);
   }
 }
 

--- a/src/components/portfolioPage/GeographicMap.jsx
+++ b/src/components/portfolioPage/GeographicMap.jsx
@@ -4,6 +4,7 @@ import {Items} from '../../model.js';
 import { GoogleMap, Marker, LoadScript } from '@react-google-maps/api';
 import Geocode from 'react-geocode';
 import memoize from 'mem';
+import Selection from '../../Selection.js';
 
 class GeographicMap extends React.PureComponent {
 
@@ -67,7 +68,7 @@ class GeographicMap extends React.PureComponent {
 
   handleClick = (place_id) => {
     let place = this.state.places.find(x => x.place_id === place_id);
-    let uri = `/?t={"type":"intersection","data":[{"type":"intersection","selection":["spatial : ${place.spatial}"],"exclusion":[]}]}`;
+    let uri = new Selection(`spatial : ${place.spatial}`).toURI();
     this.props.history.push(uri);
   }
 

--- a/src/components/portfolioPage/Portfolio.jsx
+++ b/src/components/portfolioPage/Portfolio.jsx
@@ -140,17 +140,8 @@ class Portfolio extends Component {
   }
 
   _isSelected(item) {
-    let itemHasValue = this.query.getClauses().map(l =>
-      includes(
-        this._getRecursiveItemTopics(item).concat(this._getItemAttributes(item)),
-        (l.selection || []),
-        (l.exclusion || []),
-        (l.type === 'union')
-      )
-    );
-    if (this.query.getOperator() === 'union')
-      return itemHasValue.reduce((c1, c2) => c1 || c2, false);
-    return itemHasValue.reduce((c1, c2) => c1 && c2, true);
+    let filter = this.query.toFilter();
+    return filter(this._getRecursiveItemTopics(item).concat(this._getItemAttributes(item)));
   }
 
   _updateSelectedItems() {
@@ -250,22 +241,6 @@ class Portfolio extends Component {
       />
     );
   }
-}
-function includes(array1, array2, array3, union) {
-  let set1 = new Set(array1);
-  let arrayHasValue = array2.map(e => set1.has(e));
-  let arrayDontHaveValue = array3.map(e => set1.has(e));
-  if (union)
-    return arrayHasValue.reduce((c1, c2) => c1 || c2, false)
-      || ((array3.length > 0)
-        ? !arrayDontHaveValue.reduce((c1, c2) => c1 || c2, false)
-        : false
-      );
-  return arrayHasValue.reduce((c1, c2) => c1 && c2, true)
-    && ((array3.length > 0)
-      ? !arrayDontHaveValue.reduce((c1, c2) => c1 && c2, true)
-      : true
-    );
 }
 
 function push(map, topicId, itemId) {

--- a/src/components/portfolioPage/SearchBar.jsx
+++ b/src/components/portfolioPage/SearchBar.jsx
@@ -5,6 +5,7 @@ import {Topics, Items} from '../../model.js';
 import InputWithSuggestions from '../InputWithSuggestions.jsx';
 import { t } from '@lingui/macro';
 import { i18n } from '../../index.js';
+import Selection from '../../Selection.js';
 
 class SearchBar extends React.Component {
 
@@ -39,14 +40,7 @@ class SearchBar extends React.Component {
 
   handleSuggestionSelected = (event, { suggestion }) => {
     this.setState({pattern: ''});
-    this.props.history.push('/?t=' + JSON.stringify({
-      type: 'intersection',
-      data: [{
-        type: 'intersection',
-        selection: [suggestion.id],
-        exclusion: []
-      }]
-    }));
+    this.props.history.push((new Selection(suggestion.id)).toURI());
   };
 
   render() {

--- a/src/components/portfolioPage/Topic.jsx
+++ b/src/components/portfolioPage/Topic.jsx
@@ -15,9 +15,7 @@ class Topic extends Component {
 
   render() {
     let subtopics = this._getSubtopics();
-    let isSelected = this.props.selection.includes(this.props.id);
-    let isExcluded = this.props.exclusion.includes(this.props.id);
-    let topicClasses = (isSelected ? 'Selected' : '') + ' ' + (isExcluded ? 'Excluded' : '');
+    let topicClasses = this.props.query.isSelectedOrExcluded(this.props.id);
     let topic = 'Topic ' + this.state.fold;
     let items = this.props.topicsItems.get(this.props.id);
     let count = (items) ? items.size : '';
@@ -39,8 +37,7 @@ class Topic extends Component {
     const topic = this.props.topics[this.props.id];
     return (topic.narrower || []).sort(by('name')).map(t =>
       <Topic key={t.id} id={t.id} name={t.name} topics={this.props.topics}
-        selection={this.props.selection} exclusion={this.props.exclusion}
-        selectionJSON={this.props.selectionJSON}
+        query={this.props.query}
         topicsItems={this.props.topicsItems}
         history={this.props.history}
       />
@@ -54,46 +51,8 @@ class Topic extends Component {
 
   handleClick(e) {
     e.preventDefault();
-    updateSelectionJSON(this.props.topics, this.props.id, this.props.selectionJSON);
-    this.props.history.push('/?t=' + JSON.stringify(this.props.selectionJSON));
-  }
-}
-
-function updateSelectionJSON(array, item, selection) {
-  if (selection === undefined)
-    return;
-  let found = selection.data.filter(s => {
-    let allTopics = [...(s.selection || []), ...(s.exclusion || [])];
-    if (allTopics.length === 0 || array[allTopics[0]] === undefined) {
-      return false;
-    }
-    return (!array[allTopics[0]].hasOwnProperty('broader') && !array[item].hasOwnProperty('broader'))
-      || (array[allTopics[0]].hasOwnProperty('broader') && array[allTopics[0]].broader[0].id) === (array[item].hasOwnProperty('broader') && array[item].broader[0].id);
-
-  });
-
-  if (found.length === 0) {
-    selection.data.push({type: 'intersection', selection: [item], exclusion: []});
-  } else {
-    if (!found[0].hasOwnProperty('selection'))
-      found[0].selection = [];
-    if (!found[0].hasOwnProperty('exclusion'))
-      found[0].exclusion = [];
-    switchPlace(found[0], item);
-    if ((!Array.isArray(found[0].selection) || !found[0].selection.length) && (!Array.isArray(found[0].exclusion) || !found[0].exclusion.length))
-      selection.data.splice(selection.data.indexOf(found[0]), 1);
-  }
-}
-
-function switchPlace(object, item) {
-  let index;
-  if ((index = object.selection.indexOf(item)) > -1) {
-    object.selection.splice(index, 1);
-    object.exclusion.push(item);
-  } else if ((index = object.exclusion.indexOf(item)) > -1) {
-    object.exclusion.splice(index, 1);
-  } else {
-    object.selection.push(item);
+    this.props.query.toggleTopic(this.props.id, this.props.topics);
+    this.props.history.push(this.props.query.toURI());
   }
 }
 

--- a/src/components/portfolioPage/Viewpoint.jsx
+++ b/src/components/portfolioPage/Viewpoint.jsx
@@ -27,8 +27,8 @@ class Viewpoint extends Component {
   _getTopics() {
     return (this.props.viewpoint.upper || []).sort(by('name')).map((t) =>
       <Topic key={t.id} id={t.id} name={t.name} topics={this.props.viewpoint}
-        selection={this.props.selection} selectionJSON={this.props.selectionJSON}
-        exclusion={ this.props.exclusion} topicsItems={this.props.topicsItems}
+        topicsItems={this.props.topicsItems}
+        query={this.props.query}
       />
     );
   }


### PR DESCRIPTION
## Content

FIX: Complex boolean query with "and", "or" and "not" should have the right result (fixes #366).

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [X] corresponds to a contribution that should be notified to users,
    - [X] does not generate new errors or warnings at compile or test time,
    - [X] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [X] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `TEST` when it concerns an acceptance test,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [X] be followed by a colon (`:`) with one space after and no space before,
    - [X] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [X] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [X] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [X] related to this very contribution (feature, fix...),
    - [X] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [X] without any typo in variable, class or function names,
    - [X] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
