### PR TITLE
TEST: Scenarios - Authorize a contributor to edit a viewpoint (see #183)

### DIFF
--- a/features/viewpoint_authorize_editing.feature
+++ b/features/viewpoint_authorize_editing.feature
@@ -1,0 +1,52 @@
+#language: fr
+
+Fonctionnalité: Autoriser ou non un utilisateur à éditer un point de vue
+
+Scénario: L'utilisateur est noté sur la liste d'édition du point de vue
+
+   Soit "eut-skills" le portfolio ouvert
+   Et l'utilisateur "noels" est connecté
+   Et l'utilisateur "noels" est noté sur la liste d'édition du point de vue "Informatique"
+   Quand l'utilisateur "noels" modifie l'appellation du point de vue "Informatique" par "Matériaux"
+   Alors l'appellation du point de vue est "Matériaux"
+
+Scénario: Le contributeur est l'auteur d'un point de vue
+
+   Soit l'utilisateur "alcarazc" est l'auteur du point de vue "Informatique"
+   Alors l'utilisateur "alcarazc" est noté sur la liste d'édition du point de vue "Informatique"
+
+Scénario: La liste d'édition du point de vue n'est pas définie
+
+   Soit "eut-skills" le portfolio ouvert
+   Et l'utilisateur "noels" est connecté
+   Et la liste d'édition du point de vue "Matériaux" n'existe pas
+   Quand l'utilisateur "noels" modifie l'appellation du point de vue "Matériaux" par "Chimie"
+   Alors l'appellation du point de vue est "Chimie"
+
+Scénario: L'utilisateur n'est pas noté sur la liste d'édition du point de vue
+
+   Soit "eut-skills" le portfolio ouvert  
+   Et l'utilisateur "noels" est connecté
+   Et l'utilisateur "noels" n'est pas noté sur la liste d'édition du point de vue "Mécanique"
+   Quand l'utilisateur "noels" modifie l'appellation du point de vue "Mécanique" par "Informatique"
+   Alors l'appellation du point de vue est "Mécanique"
+
+Scénario: L'utilisateur ajoute un contributeur à la liste d'édition
+
+   Soit "eut-skills" le portfolio ouvert
+   Et l'utilisateur "noels" est connecté
+   Et l'utilisateur "noels" est noté sur la liste d'édition du point de vue "Informatique"
+   Et l'utilisateur "alcarazc" n'est pas noté sur la liste d'édition du point de vue "Informatique"
+   Quand l'utilisateur "noels" ajoute l'utilisateur "alcarazc" à la liste d'édition du point de vue "Informatique"
+   Alors l'utilisateur "noels" est noté sur la liste d'édition du point de vue "Informatique"
+   Et l'utilisateur "alcarazc" est noté sur la liste d'édition du point de vue "Informatique"
+   
+Scénario: L'utilisateur ne peut pas ajouter un contributeur à la liste d'édition
+
+   Soit "eut-skills" le portfolio ouvert
+   Et l'utilisateur "noels" est connecté
+   Et l'utilisateur "noels" n'est pas noté sur la liste d'édition du point de vue "Informatique"
+   Et l'utilisateur "alcarazc" n'est pas noté sur la liste d'édition du point de vue "Informatique"
+   Quand l'utilisateur "noels" ajoute l'utilisateur "alcarazc" à la liste d'édition du point de vue "Informatique"
+   Alors l'utilisateur "noels" n'est noté pas sur la liste d'édition du point de vue "Informatique"
+   Et l'utilisateur "alcarazc" n'est pas noté sur la liste d'édition du point de vue "Informatique"


### PR DESCRIPTION
## Content

Scenarios (Gherkin) which illustrate the feature "Authorize a contributor to edit a viewpoint" (ticket  #183) done with 
 @Samnoel95. Since the ticket corresponds to a new feature, we put the scenarios in a new file named `viewpoint_authorize_editing.feature`, according to the other scenarios files in the `features` folder.

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [x] corresponds to a contribution that should be notified to users,
    - [x] does not generate new errors or warnings at compile or test time,
    - [x] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [x] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `TEST` when it concerns an acceptance test,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [x] be followed by a colon (`:`) with one space after and no space before,
    - [ x be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [x] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [x] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [x] related to this very contribution (feature, fix...),
    - [x] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [x] without any typo in variable, class or function names,
    - [x] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
