### PR TITLE
TEST: Scenarios - Authorize a contributor to edit a viewpoint (see Hypertopic#183)

### DIFF
--- a/features/authorize_editing_viewpoint.feature
+++ b/features/authorize_editing_viewpoint.feature
@@ -1,8 +1,8 @@
 #language: fr
 
-Fonctionnalité : Autoriser un contributeur à éditer un point de vue
+Fonctionnalité: Autoriser un contributeur à éditer un point de vue
 
-Scénario : L’utilisateur est contributeur 
+Scénario: L’utilisateur est contributeur 
 
 Soit l’utilisateur est connecté 
 Et l’utilisateur est contributeur
@@ -13,7 +13,7 @@ Alors le menu de modification des points de vue s’affiche
 Quand l’utilisateur clique sur "Modifier un point de vue personnel"
 Alors le menu de modification des points de vue s’affiche
 
-Scénario : L’utilisateur n’est pas contributeur 
+Scénario: L’utilisateur n’est pas contributeur 
 
 Soit l’utilisateur est connecté
 Et l’utilisateur n’est pas contributeur
@@ -22,7 +22,7 @@ Alors le bouton “Modifier un point de vue personnel ” est visible
 Quand l’utilisateur clique sur "Modifier un point de vue personnel"
 Alors le menu de modification des points de vue s’affiche
 
-Scénario : L’utilisateur n’est pas connecté 
+Scénario: L’utilisateur n’est pas connecté 
 
 Soit l’utilisateur n’est pas connecté 
 Alors le bouton "Modifier un point de vue" est invisible

--- a/features/authorize_editing_viewpoint.feature
+++ b/features/authorize_editing_viewpoint.feature
@@ -1,0 +1,39 @@
+#language: fr
+
+Fonctionnalité : Autoriser un contributeur à éditer un point de vue
+
+Scénario : L’utilisateur est contributeur 
+
+Soit l’utilisateur est connecté 
+Et l’utilisateur est contributeur
+Alors le bouton "Modifier un point de vue" est visible 
+Et le bouton “Modifier un point de vue personnel ” est visible 
+Quand l’utilisateur clique sur "Modifier un point de vue"
+Alors le menu de modification des points de vue s’affiche
+Quand l’utilisateur clique sur "Modifier un point de vue personnel"
+Alors le menu de modification des points de vue s’affiche
+
+Scénario : L’utilisateur n’est pas contributeur 
+
+Soit l’utilisateur est connecté
+Et l’utilisateur n’est pas contributeur
+Alors le bouton "Modifier un point de vue" est invisible 
+Alors le bouton “Modifier un point de vue personnel ” est visible 
+Quand l’utilisateur clique sur "Modifier un point de vue personnel"
+Alors le menu de modification des points de vue s’affiche
+
+Scénario : L’utilisateur n’est pas connecté 
+
+Soit l’utilisateur n’est pas connecté 
+Alors le bouton "Modifier un point de vue" est invisible
+Alors le bouton "Modifier un point de vue personnel" est invisible
+
+
+
+
+
+
+
+
+
+

--- a/features/authorize_editing_viewpoint.feature
+++ b/features/authorize_editing_viewpoint.feature
@@ -1,11 +1,11 @@
 #language: fr
 
-Fonctionnalité: Autoriser un contributeur à éditer un point de vue
+Fonctionnalité: Autoriser un contributeur de points de vue à éditer un point de vue
 
-Scénario: L’utilisateur est contributeur 
+Scénario: L’utilisateur est contributeur de points de vue
 
 Soit l’utilisateur est connecté 
-Et l’utilisateur est contributeur
+Et l’utilisateur est contributeur de points de vue
 Alors le bouton "Modifier un point de vue" est visible 
 Et le bouton “Modifier un point de vue personnel ” est visible 
 Quand l’utilisateur clique sur "Modifier un point de vue"
@@ -13,10 +13,10 @@ Alors le menu de modification des points de vue s’affiche
 Quand l’utilisateur clique sur "Modifier un point de vue personnel"
 Alors le menu de modification des points de vue s’affiche
 
-Scénario: L’utilisateur n’est pas contributeur 
+Scénario: L’utilisateur n’est pas contributeur de points de vue
 
 Soit l’utilisateur est connecté
-Et l’utilisateur n’est pas contributeur
+Et l’utilisateur n’est pas contributeur de points de vue
 Alors le bouton "Modifier un point de vue" est invisible 
 Alors le bouton “Modifier un point de vue personnel ” est visible 
 Quand l’utilisateur clique sur "Modifier un point de vue personnel"


### PR DESCRIPTION
Scenarios (Gherkin) which illustrate the feature "Authorize a contributor to edit a viewpoint" (ticket #183) done with
@TheoHoenen . Since the ticket corresponds to a new feature, we put the scenarios in a new file named authorize_editing_viewpoint.feature, according to the other scenarios files in the features folder.

## Content

Scénario pour l'autorisation de l'édition des points de vue pour les contributeurs mais aussi des points de vue personels pour tout les utilisateurs connectés.

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [ ] corresponds to a contribution that should be notified to users,
    - [ ] does not generate new errors or warnings at compile or test time,
    - [ ] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [ ] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `TEST` when it concerns an acceptance test,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [ ] be followed by a colon (`:`) with one space after and no space before,
    - [ ] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [ ] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [ ] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [ ] related to this very contribution (feature, fix...),
    - [ ] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [ ] without any typo in variable, class or function names,
    - [ ] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
