### PR TITLE
FEATURE: Authorize a contributor to edit a viewpoint (see #183)

### DIFF
--- a/src/components/viewpointPage/Contributors.jsx
+++ b/src/components/viewpointPage/Contributors.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import Hypertopic from 'hypertopic';
+import conf from '../../config.js';
+import {Trans} from '@lingui/macro';
+
+const _error = (x) => console.error(x.message);
+
+class Contributors extends React.Component {
+
+  constructor() {
+    super();
+    this.state = { };
+  }
+
+  render() {
+    let contributors = this.state.contributors;
+    return (
+      <div className="col-md-4 p-4 col-sm-12">
+        <div className="Description">
+          <h2 className="h4 font-weight-bold text-center"><Trans>Contributeurs</Trans></h2>
+          <div className="p-3">
+            <form className="" onSubmit={(e) => this._getContributor(e)}>
+              <div className="row">
+                <div className="col-xs-8 mx-2 mt-1">
+                  <input className="form-control" type="text" name="contributorToAdd" id="contributorToAdd"/>
+                </div>
+                <div className="col-xs-3 mt-1">
+                  <button type="submit" className="btn btn-light ml-2"><Trans>Ajouter</Trans></button>
+                </div>
+              </div>
+            </form>
+            <ul className="list-group mt-4">
+              {contributors ? contributors.map(item => <li className="list-group-item" key={item}>{item}</li>) : <Trans>Pas de contributeurs</Trans>}
+            </ul>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  componentDidMount() {
+    this._fetchData();
+  }
+
+  _getContributor(event) {
+    event.preventDefault();
+    let contributor = event.target.contributorToAdd.value;
+    if (!contributor) return;
+    this.addContributors(contributor);
+  }
+  async addContributors(contributor) {
+    const db = new Hypertopic((await conf).services);
+    db.get({ _id: this.props.viewpoint_id })
+      .then(x => {
+        x.contributors = [...new Set(x.contributors).add(contributor)];
+        return x;
+      })
+      .then(db.post)
+      .then(x => this.setState({contributors: x.contributors}))
+      .catch(_error);
+  }
+
+  async _fetchData() {
+    new Hypertopic((await conf).services)
+      .get({ _id: this.props.viewpoint_id })
+      .then(x => {
+        this.setState({contributors: x.contributors });
+      });
+  }
+
+}
+export default Contributors;

--- a/src/components/viewpointPage/Outliner.jsx
+++ b/src/components/viewpointPage/Outliner.jsx
@@ -24,6 +24,7 @@ class Outliner extends React.Component {
   render() {
     let status = this._getStatus();
     let topic = {name: this.state.title};
+    let style = this.state.title ? 'col-md-8 p-4' : 'col-md-12 p-4';
     return (
       <div className="App container-fluid">
         <Header conf={conf} />
@@ -38,7 +39,7 @@ class Outliner extends React.Component {
             {this.state.title
               ? <Contributors viewpoint_id = {this.props.match.params.id} />
               : ''}
-            <div className="col-md-8 p-4">
+            <div className={style}>
               <div className="Description">
                 <h2 className="h4 font-weight-bold text-center">{status}</h2>
                 <div className="p-3">

--- a/src/components/viewpointPage/Outliner.jsx
+++ b/src/components/viewpointPage/Outliner.jsx
@@ -7,6 +7,7 @@ import TopicTree from '../../TopicTree.js';
 import Node from './Node.jsx';
 import { t, Trans } from '@lingui/macro';
 import { i18n } from '../../index.js';
+import Contributors from './Contributors.jsx';
 
 const _log = (x) => console.log(JSON.stringify(x, null, 2));
 const _error = (x) => console.error(x.message);
@@ -34,7 +35,10 @@ class Outliner extends React.Component {
         </div>
         <div className="container-fluid">
           <div className="App-content row">
-            <div className="col-md-12 p-4">
+            {this.state.title
+              ? <Contributors viewpoint_id = {this.props.match.params.id} />
+              : ''}
+            <div className="col-md-8 p-4">
               <div className="Description">
                 <h2 className="h4 font-weight-bold text-center">{status}</h2>
                 <div className="p-3">
@@ -48,6 +52,7 @@ class Outliner extends React.Component {
                 </div>
               </div>
             </div>
+
           </div>
         </div>
       </div>
@@ -74,12 +79,20 @@ class Outliner extends React.Component {
     let title = e.target.newTitle.value;
     if (!title) return;
     let SETTINGS = await conf;
-    new Hypertopic(SETTINGS.services)
-      .post({_id: this.props.match.params.id, viewpoint_name: title, topics: {}, users: [SETTINGS.user]})
-      .then(_log)
-      .then(_ => this.setState({ title }))
-      .then(_ => this._fetchData())
-      .catch(_error);
+    let options = {};
+    options.credentials = 'include';
+    fetch(SETTINGS.services[0] + '/_session', options)
+      .then(x => x.json())
+      .then(x => {
+        if (x.name || x.userCtx.name) {
+          new Hypertopic(SETTINGS.services)
+            .post({_id: this.props.match.params.id, viewpoint_name: title, topics: {}, users: [SETTINGS.user], contributors: [ x.name || x.userCtx.name]})
+            .then(_log)
+            .then(_ => this.setState({ title }))
+            .then(_ => this._fetchData())
+            .catch(_error);
+        }
+      }).catch(_error);
   }
 
   activeNode(activeNode) {

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -127,3 +127,15 @@ msgstr "Username"
 #: src/components/itemPage/Attribute.jsx:89
 msgid "valeur"
 msgstr "value"
+
+#: src/components/viewpointPage/Contributors.jsx:28
+msgid "Ajouter"
+msgstr "Add"
+
+#: src/components/viewpointPage/Contributors.jsx:20
+msgid "Contributeurs"
+msgstr "Contributors"
+
+#: src/components/viewpointPage/Contributors.jsx:33
+msgid "Pas de contributeurs"
+msgstr "No contributors"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -127,3 +127,15 @@ msgstr "nom d'utilisateur"
 #: src/components/itemPage/Attribute.jsx:89
 msgid "valeur"
 msgstr "valeur"
+
+#: src/components/viewpointPage/Contributors.jsx:28
+msgid "Ajouter"
+msgstr "Ajouter"
+
+#: src/components/viewpointPage/Contributors.jsx:20
+msgid "Contributeurs"
+msgstr "Contributeurs"
+
+#: src/components/viewpointPage/Contributors.jsx:33
+msgid "Pas de contributeurs"
+msgstr "Pas de contributeurs"


### PR DESCRIPTION
## Content

Implementation of issue #183, made with @Anas9820.

- Viewpoints with a list of contributors can be edited only by them (but existing viewpoints, without a list or with an empty list, are still writable by any authenticated user).
- On creation, a viewpoint has its author as its only contributor.
- Any contributor of a viewpoint can authorize another user to contribute.

