### PR TITLE
TEST: Scenarios - Subscribe to a corpus (see Hypertopic#501)

### DIFF
--- a/features/subscribe_corpus.feature
+++ b/features/subscribe_corpus.feature
@@ -1,0 +1,16 @@
+#language: fr
+
+Fonctionnalité:  Etre informé des nouveautés relatives à un corpus
+
+Scénario: suite à une modification d'item
+
+Soit "Graines d'artistes" un corpus auquel l'utilisateur est abonné
+Lorsque l'item "1997_MS_06_FRA_R_A"  est modifié
+Alors l'utilisateur est informé de la modification de  l'item "1997_MS_06_FRA_R_A"  par une notification dans son client RSS
+
+Scénario: suite à un ajout d'item
+
+Soit "Graines d'artistes" un corpus auquel l'utilisateur est abonné
+Lorsque l'item "1995_5-5_55_CRI_R_A"  est ajouté 
+Alors l'utilisateur est informé de l'ajout de l'item "1995_5-5_55_CRI_R_A"  par une notification dans son client RSS
+


### PR DESCRIPTION
## Content

Scenarios which illustrate the feature "Subscribe to a corpus" (ticket #501) done with @sarah-ngn .
Since the ticket corresponds to a new feature, we put the scenarios in a new file named subscribe_corpus.feature, according to the other scenarios files in the features.

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [ ] corresponds to a contribution that should be notified to users,
    - [ ] does not generate new errors or warnings at compile or test time,
    - [ ] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [ ] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `SCENARIO` for examples showing a given behaviour,
        - `TEST` when it concerns an acceptance test of a given behaviour,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [ ] be followed by a colon (`:`) with one space after and no space before,
    - [ ] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [ ] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [ ] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [ ] related to this very contribution (feature, fix...),
    - [ ] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [ ] without any typo in variable, class or function names,
    - [ ] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
