### PR TITLE
SCENARIO: Browse items while moving in a physical space (see #369)

### DIFF
--- a/features/item_browse.feature
+++ b/features/item_browse.feature
@@ -1,0 +1,13 @@
+#language: fr
+
+Fonctionnalité: Se repérer dans l'espace
+
+Scénario: dans un édifice à un étage
+
+Soit "vitraux" le portfolio ouvert
+Quand l'utilisateur recherche "Jean" puis choisit "spatial : Église Saint-Jean-au-Marché, Troyes" 
+Alors l'item "SJ 100" est au dessus du plan 
+Et l'item "SJ 000" est au dessus de l'item "SJ 100"
+Et l'item "SJ 102" est à droite du plan 
+Et l'item "SJ 002" est à droite de l'item "SJ 102"
+Et l'item "SJ 001" est à gauche du plan


### PR DESCRIPTION
Co-Authored-By: Quentin HAINOS @qhainos
Co-Authored-By: Albert ELOMBO @albertelombo

## Content

This is the scenario designed for browsing items in the edifice. 

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [x] corresponds to a contribution that should be notified to users,
    - [x] does not generate new errors or warnings at compile or test time,
    - [x] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [x] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `SCENARIO` for examples showing a given behaviour,
        - `TEST` when it concerns an acceptance test of a given behaviour,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [x] be followed by a colon (`:`) with one space after and no space before,
    - [x] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [x] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [x] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [x] related to this very contribution (feature, fix...),
    - [x] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [x] without any typo in variable, class or function names,
    - [x] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
