### PR TITLE
FIX: Geocoding default configuration (see #349)

### DIFF
--- a/src/components/portfolioPage/GeographicMap.jsx
+++ b/src/components/portfolioPage/GeographicMap.jsx
@@ -15,17 +15,19 @@ class GeographicMap extends React.PureComponent {
   componentDidUpdate(prevProps) {
     if (this.props.items !== prevProps.items) {
       this.props.conf.then((conf) => {
-        let api_key = conf.map.key;
-        let geocoding_uri = conf.map.geocodingService;
-        if (api_key && geocoding_uri) {
-          this.setState({ api_key, geocoding_uri });
-          let addresses = new Items(this.props.items).getAttributeValues('spatial');
-          this._fetchPlaces(addresses);
-        }
-        let portfolio = conf.portfolio;
-        if (portfolio && portfolio[conf.user]) {
-          let layers = portfolio[conf.user].layers;
-          this.setState({ layers });
+        if (conf.map) {
+          let api_key = conf.map.key;
+          let geocoding_uri = conf.map.geocodingService;
+          if (api_key && geocoding_uri) {
+            this.setState({ api_key, geocoding_uri });
+            let addresses = new Items(this.props.items).getAttributeValues('spatial');
+            this._fetchPlaces(addresses);
+          }
+          let portfolio = conf.portfolio;
+          if (portfolio && portfolio[conf.user]) {
+            let layers = portfolio[conf.user].layers;
+            this.setState({ layers });
+          }
         }
       });
     }


### PR DESCRIPTION
## Content

This pull request solves an issue caused by the implementation of #349 that take place when the `map` is not present in [public/config.yml](https://github.com/Hypertopic/Porphyry/blob/ad13af6544b5f5367bc19796f8e2d9004e313ba7/public/config.yml).
The issue : 
`Unhandled Rejection (TypeError): conf.map is undefined`
in [src/components/portfolioPage/GeographicMap.jsx:18](https://github.com/Hypertopic/Porphyry/blob/ad13af6544b5f5367bc19796f8e2d9004e313ba7/src/components/portfolioPage/GeographicMap.jsx#L18)

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [X] corresponds to a contribution that should be notified to users,
    - [X] does not generate new errors or warnings at compile or test time,
    - [X] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [X] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `SCENARIO` for examples showing a given behaviour,
        - `TEST` when it concerns an acceptance test of a given behaviour,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [X] be followed by a colon (`:`) with one space after and no space before,
    - [X] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [X] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [X] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [X] related to this very contribution (feature, fix...),
    - [X] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [X] without any typo in variable, class or function names,
    - [X] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
