### PR TITLE
TEST: Register as a contributor (see #184)

### DIFF
--- a/features/step_definitions/context.rb
+++ b/features/step_definitions/context.rb
@@ -50,3 +50,10 @@ end
 Soit("la langue du navigateur est {string}") do |language|
   page.driver.add_headers("Accept-Language" => language)
 end
+
+Soit("l'utilisateur est sur la page d'édition de l'item {string}") do |item|
+  visit getURI(item)
+end
+
+
+

--- a/features/step_definitions/event.rb
+++ b/features/step_definitions/event.rb
@@ -57,3 +57,13 @@ Quand("l'utilisateur choisit l'item {string} dans le bloc Items ayant le même n
   end
 end
 
+Quand("{string} souhaite s'enregistrer comme contributeur en tant que {string} avec le mot de passe {string}") do |mail, login, password|
+  click_on "S'inscrire..."
+  expect(page).to have_content("Formulaire d'inscription")
+  range = [*'0'..'9',*'A'..'F']
+  hash = Array.new(36){ range.sample }.join
+  fill_in "email", with: hash + mail
+  fill_in "pseudo", with: login + hash
+  fill_in "password", with: password
+  click_on "Inscription"
+end

--- a/features/step_definitions/outcome.rb
+++ b/features/step_definitions/outcome.rb
@@ -35,3 +35,17 @@ end
 Alors("la page contient {string}") do |localization|
   expect(page).to have_content localization
 end
+
+
+Alors('l’utilisateur est connecté') do
+  expect(page).not_to have_content "Se connecter..."
+end
+
+Alors("l'utilisateur est redirigé vers la page d'édition de l'item {string}") do |item|
+  expect(find('.Subject h2')).to have_content item
+
+end
+
+Alors("L’utilisateur n’est pas connecté") do
+  expect(page).to have_content "Se connecter..."
+end


### PR DESCRIPTION
Realization of the #184 tests with @Samnoel95 and @Anas9820 

Note for the part : "	Et l'utilisateur est redirigé vers la page d'édition de l'item "SNZ 006" "
In the test implementation, it is very similar to "le titre de l'item affiché est {string}"", however in order to keep the sense of the scenario  we have decided to keep the  "	Et l'utilisateur est redirigé vers la page d'édition de l'item "SNZ 006" despite of its implementation.
