### PR TITLE
FIX: Search should not reset the current query (see #553).

### DIFF
--- a/features/portfolio_search.feature
+++ b/features/portfolio_search.feature
@@ -29,3 +29,19 @@ Scénario: une rubrique
   Alors l'item "SM 001 n" est affiché
   Mais l'item "SM 008 g" est caché
 
+Scénario: plusieurs attributs
+
+  Soit "vitraux" le portfolio ouvert
+  Et l'item "SJ 000" est affiché
+  Et l'item "SJ 002" est affiché
+  Et l'item "RLV 106" est caché
+  Quand l'utilisateur recherche "Saint-Jean-au-Marché" puis choisit "spatial : Église Saint-Jean-au-Marché, Troyes"
+  Et l'utilisateur recherche "vincent" puis choisit "Artiste > Vincent-Larcher"
+  Alors la recherche est "spatial : Église Saint-Jean-au-Marché, Troyes" et "Vincent-Larcher"
+  Et l'item "SJ" est caché
+  Et l'item "SJ 000" est caché
+  Et l'item "SJ 001" est caché
+  Et l'item "SJ 002" est caché
+  Et l'item "SJ 020" est caché
+  Et l'item "SJ 100" est caché
+  Et l'item "SJ 102" est caché

--- a/features/step_definitions/context.rb
+++ b/features/step_definitions/context.rb
@@ -66,4 +66,3 @@ end
 Soit("l'utilisateur est sur la page d'édition de l'item {string}") do |item|
   visit getURI(item)
 end
-

--- a/features/step_definitions/outcome.rb
+++ b/features/step_definitions/outcome.rb
@@ -47,3 +47,8 @@ end
 Alors("L’utilisateur n’est pas connecté") do
   expect(page).to have_content "Se connecter..."
 end
+
+Alors("la recherche est {string} et {string}") do |search1, search2|
+  expect(page).to have_content search1
+  expect(page).to have_content search2
+end

--- a/src/components/portfolioPage/SearchBar.jsx
+++ b/src/components/portfolioPage/SearchBar.jsx
@@ -37,9 +37,17 @@ class SearchBar extends React.Component {
     this.setState({pattern: event.target.value});
   };
 
-  handleSuggestionSelected = (event, { suggestion }) => {
+  /**
+   * On suggestion selected, toggle search selection.
+   *
+   * @param {object} selection Selection object
+   * @param {object} selection.suggestion Suggestion selected
+   */
+  handleSuggestionSelected = (_, { suggestion }) => {
     this.setState({pattern: ''});
-    this.props.history.push((new Selection(suggestion.id)).toURI());
+    const selection = Selection.fromURI();
+    selection.addTopic(suggestion.id);
+    this.props.history.push(selection.toURI());
   };
 
   render() {


### PR DESCRIPTION
Co-authored-by: Sandekuku <axelguichard.45@gmail.com>

## Content

This adds a scenario for issue #553.

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [x] corresponds to a contribution that should be notified to users,
    - [x] does not generate new errors or warnings at compile or test time,
    - [x] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [x] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `SCENARIO` for examples showing a given behaviour,
        - `TEST` when it concerns an acceptance test of a given behaviour,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [x] be followed by a colon (`:`) with one space after and no space before,
    - [x] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [x] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [x] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [x] related to this very contribution (feature, fix...),
    - [x] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [x] without any typo in variable, class or function names,
    - [x] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
