### PR TITLE
Remove a resource from an item (see #516)

### DIFF
--- a/features/remove_resource_from_item.feature
+++ b/features/remove_resource_from_item.feature
@@ -1,0 +1,12 @@
+#language: fr
+
+Fonctionnalité: Supprimer une ressource appartenant à un item
+
+  Scénario: Supprimer une ressource appartenant à un item
+
+    Soit "AXN 009" l'item affiché
+    Et l'utilisateur est connecté
+    Et la ressource "favicon.ico" existe comme ressource
+    Quand l'utilisateur supprime la ressource "favicon.ico"
+    Alors la ressource "favicon.ico" est supprimée
+

--- a/features/step_definitions/context.rb
+++ b/features/step_definitions/context.rb
@@ -85,3 +85,7 @@ Soit("l'utilisateur est sur mobile") do
   page.current_window.resize_to(320, 480)
 end
 
+Soit("la ressource {string} existe comme ressource") do |string|
+    expect(find('.attachment_list')).to have_content string
+end
+

--- a/features/step_definitions/event.rb
+++ b/features/step_definitions/event.rb
@@ -96,3 +96,7 @@ Quand("l'utilisateur supprime le point de vue") do
   end
 end
 
+Quand("l'utilisateur supprime la ressource {string}") do |string|
+    find(string).click_on class: "btn"
+end
+

--- a/features/step_definitions/outcome.rb
+++ b/features/step_definitions/outcome.rb
@@ -69,3 +69,6 @@ Alors("l'attribut {string} est absent") do |attribute|
   expect(find(".Attributes")).not_to have_content attribute
 end
 
+Alors("la ressource string est supprimée") do |string|
+    expect(find(".attachment_list")).not_to have_content string
+end


### PR DESCRIPTION
Co-authored-by: corentinprp51 <corentinprp@gmail.com>

## Content

Please describe your contribution here...

---

## Checklist

Please check that your pull request is correct:

- Each commit:
    - [ ] corresponds to a contribution that should be notified to users,
    - [ ] does not generate new errors or warnings at compile or test time,
    - [ ] must be attributed to its real authors (with correct GitHub IDs and [correct syntax for multiple authors](https://help.github.com/articles/creating-a-commit-with-multiple-authors/)).
- The title of a commit should:
    - [ ] begin with a contribution type
        - `FEATURE` for a behaviour allowing a user to do something new,
        - `FIX` for a behaviour which has been changed in order to meet user’s expectations,
        - `SCENARIO` for examples showing a given behaviour,
        - `TEST` when it concerns an acceptance test of a given behaviour,
        - `PROCESS` for a change in the way the software is built, tested, deployed,
        - `DOC` when it concerns only internal documentation (however it is better to combine it with the contribution that required this documentation change),
    - [ ] be followed by a colon (`:`) with one space after and no space before,
    - [ ] be followed by a title (written in English) as short, as user-centered and as explicit as possible
        - If it is a feature, the title must be the user action (beginning with a verb, and please not `manage`),
        - If it is a fix, the title must describe the intended behavior (with `should`).
    - [ ] ends with a reference to the corresponding ticket with the following syntax:
        - `(closes #xx)` if xx is a feature ticket (and the commit is a complete implementation),
        - `(fixes #xx)` if xx is a fix ticket (and the commit is a complete fix),
        - `(see #xx)` otherwise,
- Each committed line is:
    - [ ] useful (it would not work if removed)
        - if it is a comment line, its information could not be conveyed by better variables and function naming, better code structuring, or better commit message,
    - [ ] related to this very contribution (feature, fix...),
    - [ ] in English (with the exception of Gherkin scenarios in French and resulting steps),
    - [ ] without any typo in variable, class or function names,
    - [ ] correctly indented (spaces rather than tabs, same number of characters as in the rest of the file).
